### PR TITLE
Delete --system-libs parameter in llvm-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LCXX = clang++
 
 # local stuff
 C_FLAGS = `llvm-config --cflags` -Wall -Iincludes/ -g
-LLVM_FLAGS = `llvm-config --system-libs --libs --cflags --ldflags core analysis executionengine jit interpreter native`
+LLVM_FLAGS = `llvm-config  --libs --cflags --ldflags core analysis executionengine jit interpreter native`
 LLVM_VERSION = $(shell llvm-config --version | grep ^llvm-version | sed 's/^.* //g')
 
 # travis is a bitch so we setup its own stuff
@@ -13,7 +13,7 @@ TRAVIS_FLAGS = -ldl -ltinfo -pthread
  
 # detect LLVM flags and do additional tasks if host is Linux
 ifeq (("$(LLVM_VERSION)" "3.5" && "$(shell uname -s)" "Linux"),true)
-	LLVM_FLAGS = `llvm-config-3.5 --libs --system-libs --cflags --ldflags core analysis executionengine jit interpreter native -lz -lncurses`
+	LLVM_FLAGS = `llvm-config-3.5 --libs  --cflags --ldflags core analysis executionengine jit interpreter native -lz -lncurses`
 endif
 
 # 3.5 seems to need these flags


### PR DESCRIPTION
In my system (ubuntu 14.04 clang 3,4 , llvm 3.4) llvm-config --system-libs makes error.
So I delete it. 
man page of llvm-config there is no parameter of --system-libs. also web site(http://llvm.org/docs/CommandGuide/llvm-config.html).
please review it. thank you.
