### PR TITLE
rename LINKER_FLAGS to use camelCase

### DIFF
--- a/includes/codegen/codegen.h
+++ b/includes/codegen/codegen.h
@@ -90,7 +90,7 @@ typedef struct {
 	 */
 	WriteState writeState;
 
-	sds LINKER_FLAGS;
+	sds linkerFlags;
 
 	/**
 	 * Our index in the abstract syntax

--- a/includes/util/util.h
+++ b/includes/util/util.h
@@ -40,7 +40,7 @@ extern char* OUTPUT_EXECUTABLE_NAME;
 extern bool OUTPUT_C;
 extern char* ADDITIONAL_COMPILER_ARGS;
 extern char* COMPILER;
-extern char* LINKER_FLAGS;
+extern char* linkerFlags;
 
 /**
  * Returns if the char is ASCII

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -53,7 +53,7 @@ CodeGenerator *createCodeGenerator(Vector *sourceFiles) {
 	self->abstractSyntaxTree = NULL;
 	self->currentNode = 0;
 	self->sourceFiles = sourceFiles;
-	self->LINKER_FLAGS = sdsempty();
+	self->linkerFlags = sdsempty();
 	return self;
 }
 
@@ -603,14 +603,14 @@ void startCodeGeneration(CodeGenerator *self) {
 
 	// linker options
 	buildCommand = sdscat(buildCommand, " ");
-	buildCommand = sdscat(buildCommand, self->LINKER_FLAGS);
+	buildCommand = sdscat(buildCommand, self->linkerFlags);
 
 	// just for debug purposes
 	verboseModeMessage("running cl args: `%s`", buildCommand);
 
 	// do the command we just created
 	system(buildCommand);
-	sdsfree(self->LINKER_FLAGS);
+	sdsfree(self->linkerFlags);
 	sdsfree(buildCommand); // deallocate dat shit baby
 }
 

--- a/src/codegen/macrogen.c
+++ b/src/codegen/macrogen.c
@@ -21,9 +21,9 @@ void emitLinkerFlagMacro(CodeGenerator *self, LinkerFlagMacro *linker) {
 	memcpy(temp, &linker->flag[1], len - 2);
 	temp[len - 2] = '\0';
 
-	self->LINKER_FLAGS = sdscat(self->LINKER_FLAGS, " -l");
-	self->LINKER_FLAGS = sdscat(self->LINKER_FLAGS, temp);
-	self->LINKER_FLAGS = sdscat(self->LINKER_FLAGS, " ");
+	self->linkerFlags = sdscat(self->linkerFlags, " -l");
+	self->linkerFlags = sdscat(self->linkerFlags, temp);
+	self->linkerFlags = sdscat(self->linkerFlags, " ");
 }
 
 void emitMacroNode(CodeGenerator *self, Macro *macro) {


### PR DESCRIPTION
Doesn't make sense to have it LIKE_THIS when it's not a constant.
