### PR TITLE
Allow mutable struct members

### DIFF
--- a/src/parser/ast.c
+++ b/src/parser/ast.c
@@ -576,7 +576,6 @@ void destroyUnstructuredStatement(UnstructuredStatement *stmt) {
 		case EXPR_STAT_NODE: destroyExpression(stmt->expr); break;
 		default:
 			errorMessage("unstructured statement isn't being destroyed!?");
-	printf("%d\n", stmt->type);
 			break;
 	}
 	free(stmt);

--- a/src/parser/ast.c
+++ b/src/parser/ast.c
@@ -573,8 +573,10 @@ void destroyUnstructuredStatement(UnstructuredStatement *stmt) {
 		case LEAVE_STAT_NODE: destroyLeaveStat(stmt->leave); break;
 		case FUNCTION_CALL_NODE: destroyCall(stmt->call); break;
 		case IMPL_NODE: destroyImpl(stmt->impl); break;
+		case EXPR_STAT_NODE: destroyExpression(stmt->expr); break;
 		default:
 			errorMessage("unstructured statement isn't being destroyed!?");
+	printf("%d\n", stmt->type);
 			break;
 	}
 	free(stmt);

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -177,19 +177,19 @@ Type *parseType(Parser *self) {
 FieldDecl *parseFieldDecl(Parser *self) {
 	bool mutable = false;
 
+	if (checkTokenTypeAndContent(self, IDENTIFIER, MUT_KEYWORD, 0)) {
+		consumeToken(self);
+		mutable = true;
+	}
+
 	if (checkTokenType(self, IDENTIFIER, 0)) {
 		char *name = consumeToken(self)->content;
-
+		
 		if (checkTokenTypeAndContent(self, OPERATOR, ":", 0)) {
 			consumeToken(self);
 		}
 		else {
 			parserError("Expected colon in field declaration, found: %s", peekAtTokenStream(self, 0)->content);
-		}
-
-		if (checkTokenTypeAndContent(self, IDENTIFIER, MUT_KEYWORD, 0)) {
-			consumeToken(self);
-			mutable = true;
 		}
 
 		Type *type = parseType(self);


### PR DESCRIPTION
The following now works:

```
fn printf(format: str, _): int;

struct Test {
    mut x: int
}

fn main(): int {
    mut test: Test;
    test.x = 6;

    printf("%d\n", test.x);
    // outputs 6
}
```
