### PR TITLE
small lexer fix

### DIFF
--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -335,7 +335,7 @@ void getNextToken(Lexer *self) {
 		self->running = false;	// stop lexing
 		return;
 	}
-	else if (isDigit(self->currentChar) || self->currentChar == '.') {
+	else if (isDigit(self->currentChar)) || (self->currentChar == '.' && isDigit(peekAhead(self, 1))) {
 		// number
 		recognizeNumberToken(self);
 	}

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -335,7 +335,7 @@ void getNextToken(Lexer *self) {
 		self->running = false;	// stop lexing
 		return;
 	}
-	else if (isDigit(self->currentChar)) || (self->currentChar == '.' && isDigit(peekAhead(self, 1))) {
+	else if (isDigit(self->currentChar) || (self->currentChar == '.' && isDigit(peekAhead(self, 1)))) {
 		// number
 		recognizeNumberToken(self);
 	}


### PR DESCRIPTION
Making a bit of progress on #260, it gives a different error now!

```
_gen_struct_test.c:5:1: error: use of undeclared identifier 'x'
x=5;
^
```
