### PR TITLE
conditionally compile in LLVM support

### DIFF
--- a/includes/alloyc.h
+++ b/includes/alloyc.h
@@ -10,7 +10,9 @@
 #include "parser.h"
 #include "semantic.h"
 #include "C/codegen.h"
-#include "LLVM/codegen.h"
+#ifdef ENABLE_LLVM
+	#include "LLVM/LLVMcodegen.h"
+#endif
 
 #define DEBUG_MODE_ARG "-d"
 #define HELP_ARG       "-h"
@@ -19,7 +21,9 @@
 #define OUTPUT_C_ARG   "-c"
 #define COMPILER_ARG   "--compiler"
 #define VERSION_ARG    "--version"
-#define LLVM_ARG       "--llvm"
+#ifdef ENABLE_LLVM
+	#define LLVM_ARG       "--llvm"
+#endif
 
 /**
  * For handling command line
@@ -37,7 +41,9 @@ typedef struct {
 	Lexer *lexer;
 	Parser *parser;
 	CCodeGenerator *generator;
+#ifdef ENABLE_LLVM
 	LLVMCodeGenerator *generatorLLVM;
+#endif
 	SemanticAnalyzer *semantic;
 	Vector *sourceFiles;
 } AlloyCompiler;

--- a/includes/codegen/LLVM/LLVMcodegen.h
+++ b/includes/codegen/LLVM/LLVMcodegen.h
@@ -5,6 +5,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <llvm-c/Core.h>
+#include <llvm-c/ExecutionEngine.h>
+#include <llvm-c/Target.h>
+#include <llvm-c/Analysis.h>
+#include <llvm-c/BitWriter.h>
+
 #include "util.h"
 #include "parser.h"
 #include "vector.h"

--- a/src/codegen/LLVM/LLVMcodegen.c
+++ b/src/codegen/LLVM/LLVMcodegen.c
@@ -1,4 +1,4 @@
-#include "LLVM/codegen.h"
+#include "LLVM/LLVMcodegen.h"
 
 // Declarations
 


### PR DESCRIPTION
By running `make ENABLE_LLVM=1`, you can compile alloyc with LLVM support. 

Running `alloyc --version` will tell you if your alloyc binary has LLVM support compiled in or not.
