### PR TITLE
add free and alloc keywords

### DIFF
--- a/includes/parser/ast.h
+++ b/includes/parser/ast.h
@@ -34,10 +34,11 @@ typedef enum {
 	DECLARATION_NODE, INC_DEC_STAT_NODE, RETURN_STAT_NODE, BREAK_STAT_NODE,
 	CONTINUE_STAT_NODE, LEAVE_STAT_NODE, ASSIGNMENT_NODE, UNSTRUCTURED_STATEMENT_NODE,
 	ELSE_STAT_NODE, IF_STAT_NODE, MATCH_CLAUSE_STAT, MATCH_STAT_NODE, FOR_STAT_NODE,
-	STRUCTURED_STATEMENT_NODE, STATEMENT_NODE, TYPE_NODE, POINTER_FREE_NODE, TUPLE_TYPE_NODE,
+	STRUCTURED_STATEMENT_NODE, STATEMENT_NODE, TYPE_NODE, TUPLE_TYPE_NODE,
 	TUPLE_EXPR_NODE, OPTION_TYPE_NODE, 
 	MACRO_NODE, USE_MACRO_NODE, LINKER_FLAG_MACRO_NODE, EXPR_STAT_NODE, ARRAY_INITIALIZER_NODE, ARRAY_INDEX_NODE,
-	CHAR_LITERAL_NODE, STRING_LITERAL_NODE, INT_LITERAL_NODE, FLOAT_LITERAL_NODE, NUM_OF_NODES
+	CHAR_LITERAL_NODE, STRING_LITERAL_NODE, INT_LITERAL_NODE, FLOAT_LITERAL_NODE,
+	ALLOC_NODE, FREE_STAT_NODE, NUM_OF_NODES
 } NodeType;
 
 extern const char *NODE_NAME[];
@@ -61,6 +62,14 @@ typedef struct {
 typedef struct {
 	Vector *values;
 } IdentifierList;
+
+/**
+ * A node representing an alloc expression
+ */
+typedef struct {
+	Type *type; // if we're allocating by type
+	size_t size; // if we're allocating by set size
+} Alloc;
 
 /**
  * A node representing a char literal.
@@ -238,6 +247,10 @@ typedef struct {
 	Type *structType;
 } BinaryExpr;
 
+typedef struct {
+	Type *type;
+} FreeStat;
+
 /**
  * Inheritance "emulation", an Expression Node is the parent
  * of all expressions.
@@ -251,6 +264,7 @@ struct s_Expression {
 	ArrayInitializer *arrayInitializer;
 	ArrayIndex *arrayIndex;
 	TupleExpr *tupleExpr;
+	Alloc *alloc;
 	int exprType;
 };
 
@@ -427,10 +441,6 @@ typedef struct {
 } LeaveStat;
 
 typedef struct {
-	char *name;
-} PointerFree;
-
-typedef struct {
 	UseMacro *use;
 	LinkerFlagMacro *linker;
 	int type;
@@ -446,8 +456,8 @@ typedef struct {
 	IncDecStat *incDec;
 	Assignment *assignment;
 	Call *call;
-	PointerFree *pointerFree;
 	Expression *expr;
+	FreeStat *freeStat;
 	int type;
 } UnstructuredStatement;
 
@@ -616,7 +626,9 @@ UnstructuredStatement *createUnstructuredStatement();
 
 Macro *createMacro();
 
-PointerFree *createPointerFree(char *name);
+Alloc *createAlloc();
+
+FreeStat *createFreeStat();
 
 ElseStat *createElseStat();
 
@@ -724,7 +736,9 @@ void destroyUnstructuredStatement(UnstructuredStatement *stmt);
 
 void destroyMacro(Macro *macro);
 
-void destroyPointerFree(PointerFree *pntr);
+void destroyAlloc(Alloc *alloc);
+
+void destroyFreeStat(FreeStat *freeStat);
 
 void destroyElseStat(ElseStat *stmt);
 

--- a/includes/parser/parser.h
+++ b/includes/parser/parser.h
@@ -30,25 +30,27 @@
  * These are keywords that we use a lot in the parser code,
  * some of them need better names.
  */
-#define SET_KEYWORD					"set"
-#define VOID_KEYWORD				"void"
-#define STRUCT_KEYWORD 				"struct"
-#define USE_KEYWORD					"use"
-#define MUT_KEYWORD 				"mut"
-#define FUNCTION_KEYWORD 			"fn"
-#define SINGLE_STATEMENT_OPERATOR 	"->"
-#define IF_KEYWORD					"if"
-#define ELSE_KEYWORD				"else"
-#define FOR_KEYWORD					"for"
-#define ENUM_KEYWORD				"enum"
-#define MATCH_KEYWORD				"match"
-#define CONTINUE_KEYWORD			"continue"
-#define RETURN_KEYWORD				"return"
-#define BREAK_KEYWORD				"break"
-#define LINKER_FLAG_KEYWORD			"compiler_flag"
-#define IMPL_KEYWORD				"impl"
-#define IMPL_AS_KEYWORD				"as"
-#define ELSE_KEYWORD 				"else"
+#define SET_KEYWORD                 "set"
+#define VOID_KEYWORD                "void"
+#define STRUCT_KEYWORD              "struct"
+#define USE_KEYWORD                 "use"
+#define MUT_KEYWORD                 "mut"
+#define FUNCTION_KEYWORD            "fn"
+#define SINGLE_STATEMENT_OPERATOR   "->"
+#define IF_KEYWORD                  "if"
+#define ELSE_KEYWORD                "else"
+#define FOR_KEYWORD                 "for"
+#define ENUM_KEYWORD                "enum"
+#define MATCH_KEYWORD               "match"
+#define CONTINUE_KEYWORD            "continue"
+#define RETURN_KEYWORD              "return"
+#define BREAK_KEYWORD               "break"
+#define LINKER_FLAG_KEYWORD         "compiler_flag"
+#define IMPL_KEYWORD                "impl"
+#define IMPL_AS_KEYWORD             "as"
+#define ELSE_KEYWORD                "else"
+#define ALLOC_KEYWORD               "alloc"
+#define FREE_KEYWORD                "free"
 
 /**
  * Various operators that are used in the parser, also used
@@ -174,6 +176,13 @@ IdentifierList *parseIdentifierList(Parser *parser);
  * @param  parser the parser instance
  */
 Type *parseType(Parser *parser);
+
+/**
+ * Parses an alloc expression
+ */
+Alloc *parseAlloc(Parser *self);
+
+FreeStat *parseFreeStat(Parser *self);
 
 /**
  * Parses a Field Declaration, i.e a variable defined

--- a/src/codegen/C/codegen.c
+++ b/src/codegen/C/codegen.c
@@ -239,6 +239,8 @@ static void consumeAstNodeBy(CCodeGenerator *self, int amount);
  */
 static void traverseAST(CCodeGenerator *self);
 
+static void emitAlloc(CCodeGenerator *self, Alloc *alloc);
+
 // Definitions
 
 /**
@@ -258,6 +260,7 @@ const char *BOILERPLATE =
 "#include <stddef.h>\n"
 "#include <stdarg.h>\n"
 "#include <stdint.h>\n"
+"#include <stdlib.h>\n"
 CC_NEWLINE
 "typedef char *str;" CC_NEWLINE
 "typedef size_t usize;" CC_NEWLINE
@@ -367,6 +370,30 @@ static void emitArrayInitializer(CCodeGenerator *self, ArrayInitializer *arr) {
 	emitCode(self, "}");
 }
 
+static void emitAlloc(CCodeGenerator *self, Alloc *alloc) {
+	if (alloc->type != NULL) {
+		emitCode(self, "calloc(1, sizeof(");
+		emitType(self, alloc->type);
+		emitCode(self, "));" CC_NEWLINE);
+	}
+	else {
+		emitCode(self, "malloc(1, %d);" CC_NEWLINE);
+	}
+	
+	// Emit struct initializers TODO
+	/*for (int i = 0; i < decl->structDecl->fields->members->size; ++i) {
+		FieldDecl *fieldDecl = getVectorItem(decl->structDecl->fields->members, i);
+		if (fieldDecl->defaultValue) {
+			emitCode(self, "%s", decl->name);
+			emitCode(self, "%s", ".");
+			emitCode(self, "%s", fieldDecl->name);
+			emitCode(self, " = ");
+			emitExpression(self, fieldDecl->defaultValue);
+			emitCode(self, ";" CC_NEWLINE);
+		}
+	}*/
+}
+
 static void emitExpression(CCodeGenerator *self, Expression *expr) {
 	switch (expr->exprType) {
 		case TYPE_NODE: emitType(self, expr->type); break;
@@ -379,6 +406,7 @@ static void emitExpression(CCodeGenerator *self, Expression *expr) {
 			emitType(self, expr->type);
 			emitArrayIndex(self, expr->arrayIndex);
 		} break;
+		case ALLOC_NODE: emitAlloc(self, expr->alloc); break;
 		default:
 			errorMessage("Unknown node in expression %d", expr->exprType);
 			break;
@@ -595,13 +623,13 @@ static void emitVariableDecl(CCodeGenerator *self, VariableDecl *decl) {
 		self->writeState = WRITE_HEADER_STATE;
 	}
 
-	if (decl->structDecl) {
+	if (decl->structDecl && !decl->pointer) {
 		// Emit struct initializers
 		for (int i = 0; i < decl->structDecl->fields->members->size; ++i) {
 			FieldDecl *fieldDecl = getVectorItem(decl->structDecl->fields->members, i);
 			if (fieldDecl->defaultValue) {
 				emitCode(self, "%s", decl->name);
-				emitCode(self, "%s", decl->pointer ? "->" : ".");
+				emitCode(self, "%s", ".");
 				emitCode(self, "%s", fieldDecl->name);
 				emitCode(self, " = ");
 				emitExpression(self, fieldDecl->defaultValue);
@@ -784,6 +812,12 @@ static void emitLeaveStat(CCodeGenerator *self, LeaveStat *leave) {
 	}
 }
 
+static void emitFreeStat(CCodeGenerator *self, FreeStat *freeStat) {
+	emitCode(self, "free(");
+	emitType(self, freeStat->type);
+	emitCode(self, ");" CC_NEWLINE);
+}
+
 static void emitUnstructuredStat(CCodeGenerator *self, UnstructuredStatement *stmt) {
 	switch (stmt->type) {
 		case DECLARATION_NODE: emitDeclaration(self, stmt->decl); break;
@@ -797,9 +831,7 @@ static void emitUnstructuredStat(CCodeGenerator *self, UnstructuredStatement *st
 			break;
 		case LEAVE_STAT_NODE: emitLeaveStat(self, stmt->leave); break;
 		case ASSIGNMENT_NODE: emitAssignment(self, stmt->assignment); break;
-		case POINTER_FREE_NODE: 
-			emitCode(self, "free(%s);" CC_NEWLINE, stmt->pointerFree->name);
-			break;
+		case FREE_STAT_NODE: emitFreeStat(self, stmt->freeStat); break;
 	}
 }
 

--- a/src/codegen/C/codegen.c
+++ b/src/codegen/C/codegen.c
@@ -377,7 +377,7 @@ static void emitAlloc(CCodeGenerator *self, Alloc *alloc) {
 		emitCode(self, "));" CC_NEWLINE);
 	}
 	else {
-		emitCode(self, "malloc(1, %d);" CC_NEWLINE);
+		emitCode(self, "calloc(1, %d);" CC_NEWLINE, alloc->size);
 	}
 	
 	// Emit struct initializers TODO

--- a/src/parser/ast.c
+++ b/src/parser/ast.c
@@ -20,10 +20,11 @@ const char *NODE_NAME[] = {
 	"DECLARATION_NODE", "INC_DEC_STAT_NODE", "RETURN_STAT_NODE", "BREAK_STAT_NODE",
 	"CONTINUE_STAT_NODE", "LEAVE_STAT_NODE", "ASSIGNMENT_NODE", "UNSTRUCTURED_STATEMENT_NODE",
 	"ELSE_STAT_NODE", "IF_STAT_NODE", "MATCH_CLAUSE_STAT", "MATCH_STAT_NODE", "FOR_STAT_NODE",
-	"STRUCTURED_STATEMENT_NODE", "STATEMENT_NODE", "TYPE_NODE", "POINTER_FREE_NODE", "TUPLE_TYPE_NODE",
+	"STRUCTURED_STATEMENT_NODE", "STATEMENT_NODE", "TYPE_NODE", "TUPLE_TYPE_NODE",
 	"TUPLE_EXPR_NODE", "OPTION_TYPE_NODE", 
-	"MACRO_NODE", "USE_MACRO_NODE", "LINKER_FLAG_MACRO_NODE", "EXPR_STAT_NODE", "ARRAY_INITIALIZER_NODE", "ARRAY_INDEX_NODE",
-	"CHAR_LITERAL_NODE", "STRING_LITERAL_NODE", "INT_LITERAL_NODE", "FLOAT_LITERAL_NODE"
+	"MACRO_NODE", "USE_MACRO_NODE", "LINKER_FLAG_MACRO_NODE", "EXPR_STAT_NODE", "ARRAY_INITIALIZER_NODE",
+	"ARRAY_INDEX_NODE", "CHAR_LITERAL_NODE", "STRING_LITERAL_NODE", "INT_LITERAL_NODE",
+	"FLOAT_LITERAL_NODE", "ALLOC_NODE", "FREE_STAT_NODE"
 };
 
 // Useful for debugging
@@ -299,10 +300,12 @@ Macro *createMacro() {
 	return safeCalloc(sizeof(Macro));
 }
 
-PointerFree *createPointerFree(char *name) {
-	PointerFree *pntr = safeMalloc(sizeof(*pntr));
-	pntr->name = name;
-	return pntr;
+Alloc *createAlloc() {
+	return safeCalloc(sizeof(Alloc));
+}
+
+FreeStat *createFreeStat() {
+	return safeCalloc(sizeof(FreeStat));
 }
 
 ElseStat *createElseStat() {
@@ -512,6 +515,7 @@ void destroyExpression(Expression *expr) {
 	destroyLiteral(expr->lit);
 	destroyType(expr->type);
 	destroyUnaryExpr(expr->unary);
+	destroyAlloc(expr->alloc);
 	free(expr);
 }
 
@@ -660,6 +664,7 @@ void destroyUnstructuredStatement(UnstructuredStatement *stmt) {
 		case LEAVE_STAT_NODE: destroyLeaveStat(stmt->leave); break;
 		case FUNCTION_CALL_NODE: destroyCall(stmt->call); break;
 		case EXPR_STAT_NODE: destroyExpression(stmt->expr); break;
+		case FREE_STAT_NODE: destroyFreeStat(stmt->freeStat); break;
 		default:
 			errorMessage("Unstructured statement isn't being destroyed");
 			break;
@@ -679,8 +684,16 @@ void destroyMacro(Macro *macro) {
 	free(macro);
 }
 
-void destroyPointerFree(PointerFree *pntr) {
-	free(pntr);
+void destroyAlloc(Alloc *alloc) {
+	if (!alloc) return;
+	destroyType(alloc->type);
+	free(alloc);
+}
+
+void destroyFreeStat(FreeStat *freeStat) {
+	if (!freeStat) return;
+	destroyType(freeStat->type);
+	free(freeStat);
 }
 
 void destroyElseIfStat(ElseIfStat *stmt) {

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -1250,6 +1250,16 @@ Alloc *parseAlloc(Parser *self) {
 	if (checkTokenTypeAndContent(self, TOKEN_IDENTIFIER, ALLOC_KEYWORD, 0)) {
 		consumeToken(self);
 		
+		if (peekAtTokenStream(self, 0)->type == TOKEN_NUMBER) {
+			IntLit *intLit = parseIntLit(self);
+			if (intLit) {
+				Alloc *alloc = createAlloc();
+				alloc->size = intLit->value;
+				destroyIntLit(intLit);
+				return alloc;
+			}
+		}
+		
 		Type *type = parseType(self);
 		if (!type) {
 			parserError("Invalid type in alloc expression: `%s`", peekAtTokenStream(self, 0)->content);

--- a/src/semantic/semantic.c
+++ b/src/semantic/semantic.c
@@ -274,7 +274,7 @@ void analyzeExpression(SemanticAnalyzer *self, Expression *expr) {
 		case TYPE_NODE: analyzeTypeNode(self, expr->type); break;
 		case LITERAL_NODE: analyzeLiteralNode(self, expr->lit); break;
 		default:
-			errorMessage("Unkown node in expression: %s (%d)", getNodeTypeName(expr->exprType), expr->exprType);
+			errorMessage("Unknown node in expression: %s (%d)", getNodeTypeName(expr->exprType), expr->exprType);
 			break;
 	}
 }
@@ -286,8 +286,9 @@ void analyzeUnstructuredStatement(SemanticAnalyzer *self, UnstructuredStatement 
 		case ASSIGNMENT_NODE: analyzeAssignment(self, unstructured->assignment); break;
 		case EXPR_STAT_NODE: analyzeExpression(self, unstructured->expr); break;
 		case LEAVE_STAT_NODE: break; // TODO
+		case FREE_STAT_NODE: break; //TODO
 		default:
-			errorMessage("Unkown node in expression: %s", getNodeTypeName(unstructured->type));
+			errorMessage("Unknown node in unstructured statement: %s", getNodeTypeName(unstructured->type));
 			break;
 	}
 }

--- a/tests/alloc_test.aly
+++ b/tests/alloc_test.aly
@@ -12,4 +12,9 @@ fn main(): int {
 	^y = 6;
 	printf("y is %d\n", ^y);
 	free y;
+	
+	mut a: ^i8 = alloc 1;
+	^a = 'h';
+	printf("%s\n", a);
+	free a;
 }

--- a/tests/alloc_test.aly
+++ b/tests/alloc_test.aly
@@ -1,0 +1,15 @@
+fn printf(fmt: str, _);
+
+struct Test {
+	mut val: int
+}
+
+fn main(): int {
+	mut test: ^Test = alloc Test;
+	free test;
+	
+	mut y: ^int = alloc int;
+	^y = 6;
+	printf("y is %d\n", ^y);
+	free y;
+}


### PR DESCRIPTION
Adds `free`, and `alloc`.

Simply pass a pointer to `free`.

For `alloc`, you can give it a type name, or a number for bytes to allocate. Note that if you pass a number, it must be an integer literal right now. TODO change to expression, then make sure expression returns an integer in semantic.c

Default struct values still TODO for allocated stuff.
