### PR TITLE
type inference for array initializers work, updated tests for it too

### DIFF
--- a/includes/parser/ast.h
+++ b/includes/parser/ast.h
@@ -138,6 +138,8 @@ typedef struct {
 typedef struct {
 	char *name;
 	int type;
+	bool is_array;
+	int array_len;
 } TypeName;
 
 /**

--- a/includes/semantic/semantic.h
+++ b/includes/semantic/semantic.h
@@ -63,10 +63,12 @@ typedef struct {
 } Scope;
 
 /*
- * Heap allocation hacky stuff
+ * Represents a variable type
  */
 typedef struct {
 	int type;
+	bool is_array;
+	int array_len;
 } VarType; 
 
 /*
@@ -307,6 +309,26 @@ void pushFunctionDeclaration(SemanticAnalyzer *self, FunctionDecl *func);
 
 void pushImplDeclaration(SemanticAnalyzer *self, ImplDecl *impl);
 
+VarType *createVarType(int type);
+
+void destroyVarType(VarType *type);
+
+VarType *deduceTypeFromFunctionCall(SemanticAnalyzer *self, Call *call);
+
+VarType *deduceTypeFromTypeVal(SemanticAnalyzer *self, char *typeVal);
+
+VarType *deduceTypeFromLiteral(SemanticAnalyzer *self, Literal *lit);
+
+VarType *deduceTypeFromBinaryExpr(SemanticAnalyzer *self, BinaryExpr *expr);
+
+VarType *deduceTypeFromType(SemanticAnalyzer *self, Type *type);
+
+VarType *deduceTypeFromUnaryExpr(SemanticAnalyzer *self, UnaryExpr *expr);
+
+VarType *deduceTypeFromTypeNode(SemanticAnalyzer *self, TypeName *type);
+
+VarType *deduceTypeFromExpression(SemanticAnalyzer *self, Expression *expr);
+
 /**
  * Push a new scope to the scope stack
  * @param self  the semantic analyzer instance
@@ -318,18 +340,6 @@ void pushScope(SemanticAnalyzer *self);
  * @param self the semantic analyzer instance
  */
 void popScope(SemanticAnalyzer *self);
-
-/// TYPE CHECKING
-
-VarType *deduceTypeFromFunctionCall(SemanticAnalyzer *self, Call *call);
-
-VarType *deduceTypeFromLiteral(SemanticAnalyzer *self, Literal *lit);
-
-VarType *deduceTypeFromBinaryExpr(SemanticAnalyzer *self, BinaryExpr *expr);
-
-VarType *deduceTypeFromUnaryExpr(SemanticAnalyzer *self, UnaryExpr *expr);
-
-VariableType deduceTypeFromExpression(SemanticAnalyzer *self, Expression *expr);
 
 /**
  * Destroy the semantic analyzer instance

--- a/src/codegen/C/codegen.c
+++ b/src/codegen/C/codegen.c
@@ -608,6 +608,13 @@ static void emitVariableDecl(CCodeGenerator *self, VariableDecl *decl) {
 		emitCode(self, "]");
 	}
 
+	// HACK FOR INFERENCE
+	else if (decl->type->type == TYPE_NAME_NODE) {
+		if (decl->type->typeName->is_array) {
+			emitCode(self, "[%d]", decl->type->typeName->array_len);
+		}
+	}
+
 	if (decl->assigned) {
 		if (isHeaderVariable) {
 			emitCode(self, ";" CC_NEWLINE);
@@ -621,6 +628,13 @@ static void emitVariableDecl(CCodeGenerator *self, VariableDecl *decl) {
 				emitCode(self, "[");
 				if (decl->type->typeLit->arrayType->expr) emitExpression(self, decl->type->typeLit->arrayType->expr);
 				emitCode(self, "]");
+			}
+
+			// HACK FOR INFERENCE
+			else if (decl->type->type == TYPE_NAME_NODE) {
+				if (decl->type->typeName->is_array) {
+					emitCode(self, "[%d]", decl->type->typeName->array_len);
+				}
 			}
 		}
 		emitCode(self, " = ");

--- a/src/semantic/semantic.c
+++ b/src/semantic/semantic.c
@@ -91,11 +91,11 @@ void analyzeStructDeclaration(SemanticAnalyzer *self, StructDecl *decl) {
 	pushStructDeclaration(self, decl);
 }
 
-Type *varTypeToType(VariableType type) {
+Type *varTypeToType(VarType *type) {
 	Type *result = createType();
 	result->type = TYPE_NAME_NODE;
 
-	switch (type) {
+	switch (type->type) {
 		case INTEGER_VAR_TYPE:
 			result->typeName = createTypeName("int");
 			break;
@@ -105,12 +105,16 @@ Type *varTypeToType(VariableType type) {
 		case STRING_VAR_TYPE:
 			result->typeName = createTypeName("str");
 			break;
-		// TODO eventually runes or whatever when we do utf8???
 		case CHAR_VAR_TYPE:
 			result->typeName = createTypeName("i8");
 			break;
-		default: return NULL; // TODO error
+		default: 
+			errorMessage("Could not deduce type for <TODO> lol");
+			return NULL; // TODO error
 	}
+
+	result->typeName->is_array = type->is_array;
+	result->typeName->array_len = type->array_len;
 
 	return result;
 }
@@ -120,7 +124,7 @@ void analyzeVariableDeclaration(SemanticAnalyzer *self, VariableDecl *decl) {
 	// doesn't exist
 	if (!mapDecl) {
 		if (decl->inferred) {
-			VariableType type = deduceTypeFromExpression(self, decl->expr);
+			VarType* type = deduceTypeFromExpression(self, decl->expr);
 			decl->type = varTypeToType(type);
 		}
 		else if (decl->type->typeName) {
@@ -258,11 +262,8 @@ void analyzeTypeNode(SemanticAnalyzer *self, Type *type) {
 void analyzeLiteralNode(SemanticAnalyzer *self, Literal *lit) {
 	// TODO
 	switch (lit->type) {
-		case CHAR_LITERAL_NODE:
-			printf("char literal value: %d\n", lit->charLit->value);
-			break;
-		default:
-			printf("other literal value, type %d\n", lit->type);
+		case CHAR_LITERAL_NODE: break;
+		case INT_LITERAL_NODE: break;
 	}
 }
 

--- a/tests/autotypes_test.aly
+++ b/tests/autotypes_test.aly
@@ -1,5 +1,9 @@
 fn printf(format: str, _): int;
 
+fn add(a: int, b: int): int {
+    return a + b;
+}
+
 fn main(): int {
     y := 5;
     printf("y is %d\n", y);
@@ -18,6 +22,21 @@ fn main(): int {
 
     tree := 2.0f;
     printf("%f\n", tree);
+
+    john_carmack_age := add(5, 5);
+    printf("john is %d years old\n", john_carmack_age);
+
+    ages := [ 5, 10, 15 ];
+    ages_size: int = 3;
+    mut i := 0;
+    printf("ages are = [");
+    for i < ages_size, i = i + 1 {
+        printf("%d", ages[i]);
+        if i != ages_size - 1 {
+            printf(", ");
+        }
+    }
+    printf("]\n");
 
     return 0;
 }


### PR DESCRIPTION
This introduces type inference for arrays and functions:

``` rust
fn add(a: int, b: int): int {
   return a + b;
}

...

// these work!!
x := add(5, 5);
y := [ 0, 1, 2 3, 3, 4, 2, 3, 3];
```
