### PR TITLE
Added line and marker display to parser errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -g -w -std=c99 -Wextra -pedantic
+CFLAGS = -g -wall -std=c99 -Wextra -pedantic
 
 .PHONY: all clean
 
@@ -19,7 +19,7 @@ SOURCES = $(wildcard src/*.c) \
 
 all: ${SOURCES}
 	@mkdir -p bin/
-	@$(CC) $(CFLAGS) $(INCLUDES) ${SOURCES} -o bin/alloyc
+	$(CC) $(CFLAGS) $(INCLUDES) ${SOURCES} -o bin/alloyc
 
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -g -wall -std=c99 -Wextra -pedantic
+CFLAGS = -g -Wall -std=c99 -Wextra -pedantic
 
 .PHONY: all clean
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -g -Wall -std=c99 -Wextra -pedantic
+CFLAGS = -g -w -std=c99 -Wextra -pedantic
 
 .PHONY: all clean
 
@@ -19,11 +19,11 @@ SOURCES = $(wildcard src/*.c) \
 
 all: ${SOURCES}
 	@mkdir -p bin/
-	$(CC) $(CFLAGS) $(INCLUDES) ${SOURCES} -o bin/alloyc
+	@$(CC) $(CFLAGS) $(INCLUDES) ${SOURCES} -o bin/alloyc
 
 
 clean:
-	@rm -f *.o	
+	@rm -f *.o
 	@rm -rf bin/
 	@rm -f _gen_*	# remove any output code if it's there
 	@rm -rf *.dSYM/

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1,5 +1,5 @@
 # Alloy Reference
-This document is an informal specification for Alloy, a systems programming language. 
+This document is an informal specification for Alloy, a systems programming language.
 
 ## Guiding Principles
 Alloy is a systems programming language, intended as an alternative to C. It's main purpose is to modernize C, without deviating from C's original goal of simplicity. Alloy is written in C, the frontend and backend is all hand-written, i.e no parser or lexer libraries, and no LLVM, etc.
@@ -33,7 +33,7 @@ documenting functions, structures, enumerations, etc.
 	fn main(): int {
 
 	}
-	
+
 Comments cannot be nested.
 
 ## Primitive Types
@@ -45,20 +45,20 @@ Alloy provides various primitive types:
 	bool		unsigned 8 bits
 	char		signed 8 bits
 	uint 		an unsigned integer at least 16 bits in size
-	
+
 ## Precision Types
 The precision types are there for when you want a data type to be a specific
 size. If you're writing portable code, we suggest that you use the primitive
 types, however the precision types are available for when you need them.
-	
+
 	f32			IEEE 754 single-precision binary floating-point
 	f64			IEEE 754 double-precision binary floating-point
-	
+
 	i8			signed 8 bits
 	i16			signed 16 bits
 	i32			signed 32 bits
 	i64			signed 64 bits
-	
+
 	u8			unsigned 8 bits
 	u16			unsigned 16 bits
 	u32			unsigned 32 bits
@@ -73,13 +73,13 @@ when you are counting something that cannot be negative, typically it is used fo
 memory.
 
 	usize		unsigned at least 16 bits
-	
+
 ## Variables
 Unlike languages like C or C++, variables are immutable unless otherwise specified with
 the `mut` keyword. A variable can be defined like so:
 
 	name: type;
-	
+
 And declared as follows:
 
 	name: type = some_val;
@@ -127,14 +127,14 @@ instance:
 	mut my_tuple: (int, int);
 
 To initialize the tuple with values, we use a similar notation to the tuples signature, and we
-wrap the values in parenthesis. The order should be corresponding to the types in the signature,
+wrap the values in pipes. The order should be corresponding to the types in the signature,
 for instance:
 
 	// this is valid
-	mut my_type: (int, double) = (10, 3.4);
-	
+	mut my_type: |int, double| = |10, 3.4|;
+
 	// the following errors, note the order of the types/values
-	mut another_type: (int, double) = (3.4, 10);
+	mut another_type: |int, double| = |3.4, 10|;
 
 ### Mutability
 When a variable is mutable, it can be mutated or changed. When a variable is immutable,
@@ -144,12 +144,12 @@ to modify the variable later on in the code. For instance:
 
 	x: int = 5;
 	x = 10;			// ERROR: x is constant!
-	
+
 We can also error it like so:
 
 	x: int;			// ERROR: no value assigned for constant!
-	
-Why? Because variables are treated as constants unless otherwise specified, therefore they must 
+
+Why? Because variables are treated as constants unless otherwise specified, therefore they must
 have a value assigned on definition.
 
 ## Functions
@@ -189,9 +189,9 @@ A structure is a complex data type that defines a list of variables all grouped 
 in memory:
 
 	struct Cat {
-	
+
 	}
-	
+
 A structure contains variable definitions separated by commas. Trailing commas are allowed. For example, we can write
 a structure to define a Cat's properties like so:
 
@@ -200,12 +200,12 @@ a structure to define a Cat's properties like so:
 		age: int,
 		weight: float
 	}
-	
+
 While structures are more complex types, they are defined just as any ordinary type such as an integer
 or float:
 
 	mut terry: cat;
-	
+
 Note how the structure declared is mutable, this is because we aren't declaring any of the fields in the
 structure. We can define the contents of the structure like so:
 
@@ -214,7 +214,7 @@ structure. We can define the contents of the structure like so:
 		age: 2,
 		weight: 3.12
 	};
-	
+
 The struct initializer is a statement, therefore it must be terminated with a semi-colon. Note that
 the values in the struct initializer do not have to be in order, but we suggest you do to keep things
 consistent.
@@ -435,8 +435,7 @@ Note that `x` is not defined in the for loop, but must be defined outside of the
 ## Option Types
 Option types represent an optional value, they can either be `Some` or `None`, i.e. they can either have
 a value, or not have a value -- they are often paired with `match`.
-An option type is denoted with an open angular bracket, the type that is optional, and a closing angle
-bracket.
+An option type is denoted with a question mark and the type that is optional.
 
 	fn example(a: ?int) {
 		match a {
@@ -461,7 +460,7 @@ yet.
 	fn main() {
 		file_name: str = "vident_top_ten_favorite_bread_types.md";
 		file_contents: str = read_file(file_name, ...);
-		
+
 		match file_contents {
 			Some -> printf("file %s contains:\n %s", file_name, file_contents)
 			None -> printf("failed to read file!");

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -121,10 +121,10 @@ literals, and function calls. For instance:
 	c := a + b * 2;
 
 ## Tuples
-A tuple is define similarly to a variable, however you specify the types in parenthesis. For
+A tuple is define similarly to a variable, however you specify the types in pipes. For
 instance:
 
-	mut my_tuple: (int, int);
+	mut my_tuple: |int, int|;
 
 To initialize the tuple with values, we use a similar notation to the tuples signature, and we
 wrap the values in pipes. The order should be corresponding to the types in the signature,

--- a/includes/lexer/lexer.h
+++ b/includes/lexer/lexer.h
@@ -28,7 +28,7 @@ typedef struct {
 	size_t inputLength;		// sizeof lexer input
 	int charNumber;			// current character at line
 	int startPos;			// keeps track of positions without comments
-	bool running;			// if lexer is running 
+	bool running;			// if lexer is running
 	bool failed;			// if lexing failed
 	sds buffer;				// temporary token
 	Vector *tokenStream;	// where the tokens are stored
@@ -45,7 +45,7 @@ char* getLineNumberContext(Vector *stream, int lineNumber);
 
 /**
  * Create an instance of the Lexer
- * 
+ *
  * @param input the input to lex
  * @return instance of Lexer
  */
@@ -62,7 +62,7 @@ void startLexingFiles(Lexer *lexer, Vector *sourceFiles);
 /**
  * Simple substring, basically extracts the token from
  * the lexers input from [start .. start + length]
- * 
+ *
  * @param lexer instance of lexer
  * @param start start of the input
  * @param length of the input
@@ -73,16 +73,16 @@ char* extractToken(Lexer *lexer, int start, int length);
 /**
  * Advance to the next character, consuming the
  * current one.
- * 
+ *
  * @param lexer instance of the lexer
  */
 void consumeCharacter(Lexer *lexer);
 
 /**
  * Skips layout characters, such as spaces,
- * and comments, which are denoted with the 
+ * and comments, which are denoted with the
  * pound (#).
- * 
+ *
  * @param lexer the lexer instance
  */
 void skipLayoutAndComments(Lexer *lexer);
@@ -90,35 +90,35 @@ void skipLayoutAndComments(Lexer *lexer);
 /**
  * Checks if current character is the given character
  * otherwise throws an error
- * 
+ *
  * @param lexer the lexer instance
  */
 void expectCharacter(Lexer *lexer, char c);
 
 /**
  * Recognize an identifier
- * 
+ *
  * @param lexer the lexer instance
  */
 void recognizeIdentifierToken(Lexer *lexer);
 
 /**
  * Recognize an Integer
- * 
+ *
  * @param lexer the lexer instance
  */
 void recognizeNumberToken(Lexer *lexer);
 
 /**
  * Recognize a String
- * 
+ *
  * @param lexer the lexer instance
  */
 void recognizeStringToken(Lexer *lexer);
 
 /**
  * Recognize a Character
- * 
+ *
  * @param lexer the lexer instance
  */
 void recognizeCharacterToken(Lexer *lexer);
@@ -150,9 +150,9 @@ void recognizeSeparatorToken(Lexer *lexer);
 void recognizeErroneousToken(Lexer *lexer);
 
 /**
- * Pushes a token to the token tree, also captures the 
+ * Pushes a token to the token tree, also captures the
  * token content so you don't have to.
- * 
+ *
  * @param lexer the lexer for access to the token tree
  * @param type  the type of token
  */
@@ -169,7 +169,7 @@ void pushInitializedToken(Lexer *lexer, int type, char *content);
 /**
  * Peek ahead in the character stream by
  * the given amount
- * 
+ *
  * @lexer instance of lexer
  * @ahead amount to peek by
  * @return the char we peeked at
@@ -178,7 +178,7 @@ char peekAhead(Lexer *lexer, int ahead);
 
 /**
  * Process the next token in the token stream
- * 
+ *
  * @param lexer the lexer instance
  */
 void getNextToken(Lexer *lexer);
@@ -186,7 +186,7 @@ void getNextToken(Lexer *lexer);
 /**
  * Destroys the given lexer instance,
  * freeing any memory
- * 
+ *
  * @param lexer the lexer instance to destroy
  */
 void destroyLexer(Lexer *lexer);
@@ -195,56 +195,56 @@ void destroyLexer(Lexer *lexer);
  * @return if the character given is the end of input
  * @param ch the character to check
  */
-static inline bool isEndOfInput(char ch) { 
-	return ch == '\0'; 
+static inline bool isEndOfInput(char ch) {
+	return ch == '\0';
 }
 
 /**
  * @return if the character given is a layout character
  * @param ch the character to check
  */
-static inline bool isLayout(char ch) { 
-	return !isEndOfInput(ch) && (ch) <= ' '; 
+static inline bool isLayout(char ch) {
+	return !isEndOfInput(ch) && (ch) <= ' ';
 }
 
 /**
- * @return if the character given is a comment closer 
+ * @return if the character given is a comment closer
  * @param ch the character to check
  */
-static inline bool isCommentCloser(char ch) { 
-	return ch == '\n'; 
+static inline bool isCommentCloser(char ch) {
+	return ch == '\n';
 }
 
 /**
  * @return if the character given is an uppercase letter
  * @param ch the character to check
  */
-static inline bool isUpperLetter(char ch) { 
-	return 'A' <= ch && ch <= 'Z'; 
+static inline bool isUpperLetter(char ch) {
+	return 'A' <= ch && ch <= 'Z';
 }
 
 /**
  * @return if the character given is a lower case letter
  * @param ch the character to check
  */
-static inline bool isLowerLetter(char ch) { 
-	return 'a' <= ch && ch <= 'z'; 
+static inline bool isLowerLetter(char ch) {
+	return 'a' <= ch && ch <= 'z';
 }
 
 /**
  * @return if the character given is a letter a-z, A-Z
  * @param ch the character to check
  */
-static inline bool isLetter(char ch) { 
-	return isUpperLetter(ch) || isLowerLetter(ch); 
+static inline bool isLetter(char ch) {
+	return isUpperLetter(ch) || isLowerLetter(ch);
 }
 
 /**
  * @return if the character given is a digit 0-9
  * @param ch the character to check
  */
-static inline bool isDigit(char ch) { 
-	return '0' <= ch && ch <= '9'; 
+static inline bool isDigit(char ch) {
+	return '0' <= ch && ch <= '9';
 }
 
 /**
@@ -275,60 +275,61 @@ static inline bool isOctChar(char ch) {
  * @return if the character given is a letter or digit a-z, A-Z, 0-9
  * @param ch the character to check
  */
-static inline bool isLetterOrDigit(char ch) { 
-	return isLetter(ch) || isDigit(ch); 
+static inline bool isLetterOrDigit(char ch) {
+	return isLetter(ch) || isDigit(ch);
 }
 
 /**
  * @return if the character given is an underscore
  * @param ch the character to check
  */
-static inline bool isUnderscore(char ch) { 
-	return ch == '_'; 
+static inline bool isUnderscore(char ch) {
+	return ch == '_';
 }
 
 /**
  * @return if the character given is a quote, denoting a string
  * @param ch the character to check
  */
-static inline bool isString(char ch) { 
-	return ch == '"'; 
+static inline bool isString(char ch) {
+	return ch == '"';
 }
 
 /**
  * @return if the character given is a single quote, denoting a character
  * @param ch the character to check
  */
-static inline bool isCharacter(char ch) { 
-	return ch == '\''; 
+static inline bool isCharacter(char ch) {
+	return ch == '\'';
 }
 
 /**
  * @return if the character given is an operator
  * @param ch the character to check
  */
-static inline bool isOperator(char ch) { 
-	return (strchr("+-*/=><!~?:|&%^\"'", ch) != 0); 
+static inline bool isOperator(char ch) {
+	return (strchr("+-*/=><!~?:|&%^\"'", ch) != 0);
 }
 
-static inline bool isExpressionOperator(char ch) { 
-	return (strchr("+-*/=><!~?:|&%^\"'()", ch) != 0); 
+static inline bool isExpressionOperator(char ch) {
+	return (strchr("+-*/=><!~?:|&%^\"'()", ch) != 0);
 }
 
 /**
  * @return if the character given is a separator
  * @param ch the character to check
  */
-static inline bool isSeparator(char ch) { 
-	return (strchr(" ;,.`@(){}[] ", ch) != 0); 
+static inline bool isSeparator(char ch) {
+	return (strchr(" ;,.`@(){}[] ", ch) != 0);
 }
 
 /**
  * @return if the character is end of line to track line number
  * @param ch character to check
  */
-static inline bool isEndOfLine(char ch) { 
-	return ch == '\n'; 
+static inline bool isEndOfLine(char ch) {
+	return ch == '\n';
 }
+
 
 #endif // __LEXER_H

--- a/includes/lexer/token.h
+++ b/includes/lexer/token.h
@@ -33,8 +33,7 @@ typedef enum {
  * line_number 	- the line number of the token
  * charStart 	- the column of the first character in this token
  * charEnd		- the column of the last character in this token
- * inputStart	- the index in the input at which this token starts
- * inputEnd		- the index in the input at which this token ends
+ * inputStart	- the index in the input at which this token's line starts
  */
 typedef struct {
 	int type;
@@ -43,7 +42,6 @@ typedef struct {
 	int charStart;
 	int charEnd;
 	int inputStart;
-	int inputEnd;
 	sds fileName;
 } Token;
 
@@ -53,7 +51,7 @@ typedef struct {
  * @param lineNumber the line number of the token
  * @param charNumber the character number
  */
-Token *createToken(int lineNumber, int charStart, int charEnd, int inputStart, int inputEnd, sds fileName);
+Token *createToken(int lineNumber, int charStart, int charEnd, int inputStart, sds fileName);
 
 /**
  * Retrieve the token name of the given token

--- a/includes/lexer/token.h
+++ b/includes/lexer/token.h
@@ -31,13 +31,19 @@ typedef enum {
  * type 		- the token type
  * content 		- the token content
  * line_number 	- the line number of the token
- * char_number 	- the number of the char of the token
+ * charStart 	- the column of the first character in this token
+ * charEnd		- the column of the last character in this token
+ * inputStart	- the index in the input at which this token starts
+ * inputEnd		- the index in the input at which this token ends
  */
 typedef struct {
 	int type;
 	sds content;
 	int lineNumber;
-	int charNumber;
+	int charStart;
+	int charEnd;
+	int inputStart;
+	int inputEnd;
 	sds fileName;
 } Token;
 
@@ -47,7 +53,7 @@ typedef struct {
  * @param lineNumber the line number of the token
  * @param charNumber the character number
  */
-Token *createToken(int lineNumber, int charNumber, sds fileName);
+Token *createToken(int lineNumber, int charStart, int charEnd, int inputStart, int inputEnd, sds fileName);
 
 /**
  * Retrieve the token name of the given token

--- a/includes/parser/parser.h
+++ b/includes/parser/parser.h
@@ -95,6 +95,7 @@ int getTypeFromString(char *type);
 typedef struct {
 	Vector *tokenStream;	// the stream of tokens to parse
 	Vector *parseTree;		// the AST created
+	char* src;				// The file's contents
 
 	map_t binopPrecedence;
 	int tokenIndex;			// current token
@@ -196,7 +197,7 @@ FieldDeclList *parseFieldDeclList(Parser *parser);
 StructDecl *parseStructDecl(Parser *parser);
 
 /**
- * Parses a parameter section, i.e a parameter in a 
+ * Parses a parameter section, i.e a parameter in a
  * parameter list, for instance: a: int is a parameter
  * section
  * @param  parser the parser instance
@@ -424,7 +425,7 @@ Statement *wrapExpressionInReturnStat(Expression *expr);
 
 /**
  * Creates a new Precedence to be stored in a hashmap,
- * this is a small workaround for allocating it on the 
+ * this is a small workaround for allocating it on the
  * heap cleanly.
  * @param  prec the precedence to create
  */

--- a/includes/semantic/semantic.h
+++ b/includes/semantic/semantic.h
@@ -65,7 +65,7 @@ typedef struct {
  */
 typedef struct {
 	int type;
-} VarType; 
+} VarType;
 
 /*
  * Create a new Scope

--- a/includes/util/util.h
+++ b/includes/util/util.h
@@ -144,7 +144,7 @@ void errorMessageWithPosition(char *fileName, int lineNumber, int charNumber, in
  * @param msg           the message to print
  * @param ... 			extra arguments
  */
-void errorMessageWithPositionAndLine(char* src, char *fileName, int lineNumber, int charNumber, int charEnd, int inputStart, int inputEnd, const char *fmt, ...);
+void errorMessageWithPositionAndLine(char* src, char *fileName, int lineNumber, int charNumber, int charEnd, int inputStart, const char *fmt, ...);
 
 /**
  * Emits a primary message to the console

--- a/includes/util/util.h
+++ b/includes/util/util.h
@@ -98,10 +98,11 @@ void warningMessage(const char *fmt, ...);
  * @param fileName      the filename to print (can be NULL)
  * @param lineNumber    the line number to print
  * @param charNumber    the character number to print
+ * @param charEnd	    the end character number to print
  * @param msg           the message to print
  * @param ... 			extra arguments
  */
-void warningMessageWithPosition(char *fileName, int lineNumber, int charNumber, const char *fmt, ...);
+void warningMessageWithPosition(char *fileName, int lineNumber, int charNumber, int charEnd, const char *fmt, ...);
 
 /**
  * Emits a message when in verbose mode
@@ -123,10 +124,27 @@ void errorMessage(const char *fmt, ...);
  * @param fileName      the filename to print (can be NULL)
  * @param lineNumber    the line number to print
  * @param charNumber    the character number to print
+ * @param charEnd	    the end character number to print
  * @param msg           the message to print
  * @param ... 			extra arguments
  */
-void errorMessageWithPosition(char *fileName, int lineNumber, int charNumber, const char *fmt, ...);
+void errorMessageWithPosition(char *fileName, int lineNumber, int charNumber, int charEnd, const char *fmt, ...);
+
+/**
+ * Emits an error message to the console, will also exit
+ * The error message contains a line and character number.
+ * After printing the error message, the errored line and position are displayed
+ * @param src			the file's contents
+ * @param fileName      the filename to print (can be NULL)
+ * @param lineNumber    the line number to print
+ * @param charNumber    the character number to print
+ * @param charEnd	    the end character number to print
+ * @param inputStart 	the start of the input where the error occurred
+ * @param inputEnd		the end of the input where the error occured
+ * @param msg           the message to print
+ * @param ... 			extra arguments
+ */
+void errorMessageWithPositionAndLine(char* src, char *fileName, int lineNumber, int charNumber, int charEnd, int inputStart, int inputEnd, const char *fmt, ...);
 
 /**
  * Emits a primary message to the console

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -306,7 +306,7 @@ void recognizeErroneousToken(Lexer *self) {
 /** pushes a token with no content */
 void pushToken(Lexer *self, int type) {
 	int tokenLength = self->pos - self->startPos; // The length (in characters) of this token
-	Token *tok = createToken(self->lineNumber, self->charNumber-tokenLength, self->charNumber, self->startPos, self->pos, self->fileName);
+	Token *tok = createToken(self->lineNumber, self->charNumber-tokenLength, self->charNumber, self->startPos, self->fileName);
 	tok->type = type;
 	tok->content = extractToken(self, self->startPos, self->pos - self->startPos);
 	pushBackItem(self->tokenStream, tok);
@@ -315,7 +315,7 @@ void pushToken(Lexer *self, int type) {
 /** pushes a token with content */
 void pushInitializedToken(Lexer *self, int type, char *content) {
 	int tokenLength = self->pos - self->startPos; // The length (in characters) of this token
-	Token *tok = createToken(self->lineNumber, self->charNumber-tokenLength, self->charNumber, self->startPos, self->pos, self->fileName);
+	Token *tok = createToken(self->lineNumber, self->charNumber-tokenLength, self->charNumber, self->startPos, self->fileName);
 	tok->type = type;
 	tok->content = content;
 	pushBackItem(self->tokenStream, tok);

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -59,7 +59,7 @@ void consumeCharacter(Lexer *self) {
 		self->charNumber = 0;	// reset the char number back to zero
 		self->lineNumber++;
 	}
-    
+
 	self->currentChar = self->input[++self->pos];
 	self->charNumber++;
 }
@@ -80,7 +80,7 @@ void skipLayoutAndComments(Lexer *self) {
 			if (isEndOfInput(self->currentChar)) return;
 			consumeCharacter(self);
 		}
-		
+
 		while (isLayout(self->currentChar)) {
 			consumeCharacter(self);
 		}
@@ -123,7 +123,7 @@ void skipLayoutAndComments(Lexer *self) {
 			if (isEndOfInput(self->currentChar)) return;
 			consumeCharacter(self);
 		}
-		
+
 		while (isLayout(self->currentChar)) {
 			consumeCharacter(self);
 		}
@@ -170,7 +170,7 @@ void recognizeNumberToken(Lexer *self) {
 
 	if (self->currentChar == '.') {
 		consumeCharacter(self); // consume dot
-		
+
 		while (isDigit(self->currentChar)) {
 			consumeCharacter(self);
 		}
@@ -187,7 +187,7 @@ void recognizeNumberToken(Lexer *self) {
 		while (isHexChar(self->currentChar)) {
 			consumeCharacter(self);
 		}
-		
+
 		pushToken(self, TOKEN_NUMBER);
 	}
 	else if (self->currentChar == 'b') {
@@ -196,7 +196,7 @@ void recognizeNumberToken(Lexer *self) {
 		while (isBinChar(self->currentChar)) {
 			consumeCharacter(self);
 		}
-		
+
 		pushToken(self, TOKEN_NUMBER);
 	}
 	else if (self->currentChar == 'o') {
@@ -205,11 +205,11 @@ void recognizeNumberToken(Lexer *self) {
 		while (isOctChar(self->currentChar)) {
 			consumeCharacter(self);
 		}
-		
+
 		pushToken(self, TOKEN_NUMBER);
 	}
 	else {
-		// it'll do 
+		// it'll do
 		bool isDecimal = false;
 
 		while (isDigit(self->currentChar)) {
@@ -242,7 +242,7 @@ void recognizeStringToken(Lexer *self) {
 	while (!isString(self->currentChar)) {
 		consumeCharacter(self);
 		if (isEndOfInput(self->currentChar)) {
-			errorMessageWithPosition(self->fileName, errline, errpos, "Unterminated string literal");
+			errorMessageWithPosition(self->fileName, errline, errpos, self->pos, "Unterminated string literal");
 		}
 	}
 
@@ -253,16 +253,16 @@ void recognizeStringToken(Lexer *self) {
 
 void recognizeCharacterToken(Lexer *self) {
 	expectCharacter(self, '\'');
-	
+
 	int errpos = self->charNumber;
 	int errline = self->lineNumber;
 	if (self->currentChar == '\'')
-		errorMessageWithPosition(self->fileName, self->lineNumber, self->charNumber, "Empty character literal");
-	
+		errorMessageWithPosition(self->fileName, self->lineNumber, self->charNumber, self->pos, "Empty character literal");
+
 	while (!(self->currentChar == '\'' && peekAhead(self, -1) != '\\')) {
 		consumeCharacter(self);
 		if (isEndOfInput(self->currentChar)) {
-			errorMessageWithPosition(self->fileName, errline, errpos, "Unterminated character literal");
+			errorMessageWithPosition(self->fileName, errline, errpos, self->pos, "Unterminated character literal");
 		}
 	}
 
@@ -305,7 +305,8 @@ void recognizeErroneousToken(Lexer *self) {
 
 /** pushes a token with no content */
 void pushToken(Lexer *self, int type) {
-	Token *tok = createToken(self->lineNumber, self->charNumber, self->fileName);
+	int tokenLength = self->pos - self->startPos; // The length (in characters) of this token
+	Token *tok = createToken(self->lineNumber, self->charNumber-tokenLength, self->charNumber, self->startPos, self->pos, self->fileName);
 	tok->type = type;
 	tok->content = extractToken(self, self->startPos, self->pos - self->startPos);
 	pushBackItem(self->tokenStream, tok);
@@ -313,7 +314,8 @@ void pushToken(Lexer *self, int type) {
 
 /** pushes a token with content */
 void pushInitializedToken(Lexer *self, int type, char *content) {
-	Token *tok = createToken(self->lineNumber, self->charNumber, self->fileName);
+	int tokenLength = self->pos - self->startPos; // The length (in characters) of this token
+	Token *tok = createToken(self->lineNumber, self->charNumber-tokenLength, self->charNumber, self->startPos, self->pos, self->fileName);
 	tok->type = type;
 	tok->content = content;
 	pushBackItem(self->tokenStream, tok);

--- a/src/lexer/token.c
+++ b/src/lexer/token.c
@@ -1,18 +1,21 @@
 #include "token.h"
 
-Token *createToken(int lineNumber, int charNumber, sds fileName) {
+Token *createToken(int lineNumber, int charStart, int charEnd, int inputStart, int inputEnd, sds fileName) {
 	Token *tok = safeMalloc(sizeof(*tok));
 	tok->type = TOKEN_UNKNOWN;
 	tok->content = NULL;
 	tok->lineNumber = lineNumber;
-	tok->charNumber = charNumber;
+	tok->charEnd = charEnd;
+	tok->charStart = charStart;
+	tok->inputStart = inputStart;
+	tok->inputEnd = inputEnd;
 	tok->fileName = fileName;
 	return tok;
 }
 
 char* getTokenContext(Vector *stream, Token *tok) {
 	sds result = sdsempty();
-	
+
 	for (int i = 0; i < stream->size; i++) {
 		Token *tempTok = getVectorItem(stream, i);
 		if (tempTok->lineNumber == tok->lineNumber) {

--- a/src/lexer/token.c
+++ b/src/lexer/token.c
@@ -1,6 +1,6 @@
 #include "token.h"
 
-Token *createToken(int lineNumber, int charStart, int charEnd, int inputStart, int inputEnd, sds fileName) {
+Token *createToken(int lineNumber, int charStart, int charEnd, int inputStart, sds fileName) {
 	Token *tok = safeMalloc(sizeof(*tok));
 	tok->type = TOKEN_UNKNOWN;
 	tok->content = NULL;
@@ -8,7 +8,6 @@ Token *createToken(int lineNumber, int charStart, int charEnd, int inputStart, i
 	tok->charEnd = charEnd;
 	tok->charStart = charStart;
 	tok->inputStart = inputStart;
-	tok->inputEnd = inputEnd;
 	tok->fileName = fileName;
 	return tok;
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -8,7 +8,6 @@
 				        peekAtTokenStream(self, 0)->charStart,\
 						peekAtTokenStream(self, 0)->charEnd,\
 						peekAtTokenStream(self, 0)->inputStart,\
-						peekAtTokenStream(self, 0)->inputEnd,\
 				        __VA_ARGS__)
 
 #define PRINT_CURR_TOK() printf("current token: %s\n", peekAtTokenStream(self, 0)->content);

--- a/src/semantic/semantic.c
+++ b/src/semantic/semantic.c
@@ -38,7 +38,7 @@ SemanticAnalyzer *createSemanticAnalyzer(Vector *sourceFiles) {
 	hashmap_put(self->dataTypes, "i16", createVarType(INTEGER_VAR_TYPE));
 	hashmap_put(self->dataTypes, "i32", createVarType(INTEGER_VAR_TYPE));
 	hashmap_put(self->dataTypes, "i64", createVarType(INTEGER_VAR_TYPE));
-	
+
 	hashmap_put(self->dataTypes, "u8", createVarType(INTEGER_VAR_TYPE));
 	hashmap_put(self->dataTypes, "u16", createVarType(INTEGER_VAR_TYPE));
 	hashmap_put(self->dataTypes, "u32", createVarType(INTEGER_VAR_TYPE));
@@ -46,7 +46,7 @@ SemanticAnalyzer *createSemanticAnalyzer(Vector *sourceFiles) {
 
 	hashmap_put(self->dataTypes, "f32", createVarType(INTEGER_VAR_TYPE));
 	hashmap_put(self->dataTypes, "f64", createVarType(INTEGER_VAR_TYPE));
-	
+
 	hashmap_put(self->dataTypes, "int", createVarType(INTEGER_VAR_TYPE));
 	hashmap_put(self->dataTypes, "char", createVarType(INTEGER_VAR_TYPE));
 	hashmap_put(self->dataTypes, "str", createVarType(INTEGER_VAR_TYPE));
@@ -126,7 +126,7 @@ void analyzeVariableDeclaration(SemanticAnalyzer *self, VariableDecl *decl) {
 void analyzeAssignment(SemanticAnalyzer *self, Assignment *assign) {
 	VariableDecl *mapDecl = checkVariableExists(self, assign->iden);
 	ParameterSection *paramDecl = checkLocalParameterExists(self, assign->iden);
-	
+
 	// check assign thing exists
 	if (!mapDecl && !paramDecl) {
 		semanticError("`%s` undeclared", assign->iden);
@@ -149,7 +149,7 @@ void analyzeDeclaration(SemanticAnalyzer *self, Declaration *decl) {
 void analyzeFunctionCall(SemanticAnalyzer *self, Call *call) {
 	char *callee = getVectorItem(call->callee, 0);
 
-	FunctionDecl *decl = checkFunctionExists(self, callee);	
+	FunctionDecl *decl = checkFunctionExists(self, callee);
 	if (!decl) {
 		semanticError("Attempting to call undefined function `%s`", callee);
 	}
@@ -239,10 +239,10 @@ void analyzeStructuredStatement(SemanticAnalyzer *self, StructuredStatement *str
 
 void analyzeStatement(SemanticAnalyzer *self, Statement *stmt) {
 	switch (stmt->type) {
-		case UNSTRUCTURED_STATEMENT_NODE: 
+		case UNSTRUCTURED_STATEMENT_NODE:
 			analyzeUnstructuredStatement(self, stmt->unstructured);
 			break;
-		case STRUCTURED_STATEMENT_NODE: 
+		case STRUCTURED_STATEMENT_NODE:
 			analyzeStructuredStatement(self, stmt->structured);
 			break;
 	}
@@ -263,7 +263,7 @@ void startSemanticAnalysis(SemanticAnalyzer *self) {
 		self->currentNode = 0;
 		self->currentSourceFile = sf;
 		self->abstractSyntaxTree = self->currentSourceFile->ast;
-		
+
 		for (int j = 0; j < self->abstractSyntaxTree->size; j++) {
 			Statement *stmt = getVectorItem(self->abstractSyntaxTree, j);
 			analyzeStatement(self, stmt);

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -138,15 +138,15 @@ void warningMessage(const char *fmt, ...) {
 	va_end(arg);
 }
 
-void warningMessageWithPosition(char *fileName, int lineNumber, int charNumber, const char *fmt, ...) {
+void warningMessageWithPosition(char *fileName, int lineNumber, int charNumber, int charEnd, const char *fmt, ...) {
 	va_list arg;
 	va_start(arg, fmt);
 	char *temp = GET_ORANGE_TEXT("warning: ");
 	fprintf(stderr, "%s", temp);
 	if (fileName != NULL)
-		fprintf(stderr, "[%s:%d:%d] ", fileName, lineNumber, charNumber);
+		fprintf(stderr, "[%s:%d:%d-%d] ", fileName, lineNumber, charNumber, charEnd);
 	else
-		fprintf(stderr, "[%d:%d] ", lineNumber, charNumber);
+		fprintf(stderr, "[%d:%d-%d] ", lineNumber, charNumber, charEnd);
 	vfprintf(stderr, fmt, arg);
 	fprintf(stderr, "\n");
 	va_end(arg);
@@ -163,18 +163,50 @@ void errorMessage(const char *fmt, ...) {
 	exit(1);
 }
 
-void errorMessageWithPosition(char *fileName, int lineNumber, int charNumber, const char *fmt, ...) {
+void errorMessageWithPosition(char *fileName, int lineNumber, int charStart, int charEnd, const char *fmt, ...) {
 	va_list arg;
 	va_start(arg, fmt);
 	char *temp = GET_RED_TEXT("error: ");
 	fprintf(stderr, "%s", temp);
 	if (fileName != NULL)
-		fprintf(stderr, "[%s:%d:%d] ", fileName, lineNumber, charNumber);
+		fprintf(stderr, "[%s:%d:%d-%d] ", fileName, lineNumber, charStart, charEnd);
 	else
-		fprintf(stderr, "[%d:%d] ", lineNumber, charNumber);
+		fprintf(stderr, "[%d:%d-%d] ", lineNumber, charStart, charEnd);
 	vfprintf(stderr, fmt, arg);
 	fprintf(stderr, "\n");
 	va_end(arg);
+	exit(1);
+}
+
+void errorMessageWithPositionAndLine(char* src, char *fileName, int lineNumber, int charStart, int charEnd, int inputStart, int inputEnd, const char *fmt, ...){
+	// Print the error message
+	va_list arg;
+	va_start(arg, fmt);
+	char *temp = GET_RED_TEXT("error: ");
+	fprintf(stderr, "%s", temp);
+	if (fileName != NULL)
+		fprintf(stderr, "[%s:%d:%d-%d] ", fileName, lineNumber, charStart, charEnd);
+	else
+		fprintf(stderr, "[%d:%d-%d] ", lineNumber, charStart, charEnd);
+	vfprintf(stderr, fmt, arg);
+	fprintf(stderr, "\n");
+	va_end(arg);
+
+	// Print the line and marker
+
+	int tokLength = charEnd-charStart;
+	char* line = src+inputStart-charStart;
+
+	for(int i = inputStart-charStart; i < inputEnd; line++, i++) fprintf(stderr, "%c", *line);
+	fprintf(stderr, "\n");
+	for(int i = 0; i < charStart - 1; i++) fprintf(stderr, " ");
+
+	if(tokLength > 1){
+
+		fprintf(stderr, "^");
+		for(int i = 0; i < tokLength - 2; i++) fprintf(stderr, "-");
+	}
+	fprintf(stderr, "^\n");
 	exit(1);
 }
 
@@ -184,7 +216,7 @@ void primaryMessage(const char *fmt, ...) {
 	vfprintf(stdout, fmt, arg);
 	fprintf(stdout, "\n");
 	va_end(arg);
-} 
+}
 
 const char *getFilenameExtension(const char *filename) {
 	const char *dot = strrchr(filename, '.');

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -178,7 +178,7 @@ void errorMessageWithPosition(char *fileName, int lineNumber, int charStart, int
 	exit(1);
 }
 
-void errorMessageWithPositionAndLine(char* src, char *fileName, int lineNumber, int charStart, int charEnd, int inputStart, int inputEnd, const char *fmt, ...){
+void errorMessageWithPositionAndLine(char* src, char *fileName, int lineNumber, int charStart, int charEnd, int inputStart, const char *fmt, ...){
 	// Print the error message
 	va_list arg;
 	va_start(arg, fmt);
@@ -197,7 +197,7 @@ void errorMessageWithPositionAndLine(char* src, char *fileName, int lineNumber, 
 	int tokLength = charEnd-charStart;
 	char* line = src+inputStart-charStart;
 
-	for(int i = inputStart-charStart; i < inputEnd; line++, i++) fprintf(stderr, "%c", *line);
+	for(int i = inputStart-charStart; i < inputStart-charStart+charEnd; line++, i++) fprintf(stderr, "%c", *line);
 	fprintf(stderr, "\n");
 	for(int i = 0; i < charStart - 1; i++) fprintf(stderr, " ");
 

--- a/tests/charend_test.aly
+++ b/tests/charend_test.aly
@@ -1,0 +1,3 @@
+fn main(): int
+    fooooo
+}


### PR DESCRIPTION
You can ignore the first two commits from this request, as they are from an earlier pull request.

I added the **charEnd** (the column of the last char in the token), **inputStart** (the file contents index where this token's line starts) to the **Token** struct.
Added the **errorMessageWithPositionAndLine()** function and renamed **charNumber** in the **Token** struct to **charStart** to make it more clear that it represents the column where the token starts.
I also changed the relevant functions in order to add the new variables to the created tokens.
