### PR TITLE
Add support for attribute blocks

### DIFF
--- a/parser/attr.go
+++ b/parser/attr.go
@@ -17,8 +17,9 @@ func Get(s string) *Attr {}
 */
 
 type Attr struct {
-	Key   string
-	Value string
+	Key       string
+	Value     string
+	FromBlock bool
 	nodePos
 }
 
@@ -44,7 +45,10 @@ func getAttr(attrs []*Attr, s string) *Attr {
 func (v *semanticAnalyzer) checkAttrsDistanceFromLine(attrs []*Attr, line int, declType, declName string) {
 	for i := len(attrs) - 1; i >= 0; i-- {
 		if attrs[i].lineNumber < line-1 {
-			v.warn(attrs[i], "Gap of %d lines between declaration of %s `%s` and `%s` attribute", line-attrs[i].lineNumber, declType, declName, attrs[i].Key)
+			// mute warnings from attribute blocks
+			if !attrs[i].FromBlock {
+				v.warn(attrs[i], "Gap of %d lines between declaration of %s `%s` and `%s` attribute", line-attrs[i].lineNumber, declType, declName, attrs[i].Key)
+			}
 		}
 		line = attrs[i].lineNumber
 	}

--- a/tests/attribute_block_test.ark
+++ b/tests/attribute_block_test.ark
@@ -1,0 +1,18 @@
+[c] {
+    // Single block works like expected
+	func some_func();
+	func some_other_func();
+}
+
+[c] {
+	[deprecated] {
+		// Nested block apply all their attributes
+		func third_func();
+		func fourth_func();
+	}
+	func fifth_func();
+}
+
+func main() {
+	
+}


### PR DESCRIPTION
As the title suggests, this pull adds support for attribute blocks.

The implementation allow both for plain attribute blocks, but also support nested blocks as showcased in the added test.
