### PR TITLE
Implement tuples.

### DIFF
--- a/codegen/LLVMCodegen/codegen.go
+++ b/codegen/LLVMCodegen/codegen.go
@@ -571,8 +571,12 @@ func (v *Codegen) genAddressOfExpr(n *parser.AddressOfExpr) llvm.Value {
 			index := n.Access.Accesses[i].Variable.Type.(*parser.StructType).VariableIndex(n.Access.Accesses[i+1].Variable)
 			gep = v.builder.CreateGEP(gep, []llvm.Value{llvm.ConstInt(llvm.Int32Type(), 0, false), llvm.ConstInt(llvm.Int32Type(), uint64(index), false)}, "")
 
+		case parser.ACCESS_TUPLE:
+			index := n.Access.Accesses[i].Index
+			gep = v.builder.CreateGEP(gep, []llvm.Value{llvm.ConstInt(llvm.Int32Type(), 0, false), llvm.ConstInt(llvm.Int32Type(), index, false)}, "")
+
 		default:
-			panic("")
+			panic("unhandled access type")
 		}
 	}
 

--- a/codegen/LLVMCodegen/codegen.go
+++ b/codegen/LLVMCodegen/codegen.go
@@ -623,7 +623,13 @@ func (v *Codegen) genArrayLiteral(n *parser.ArrayLiteral) llvm.Value {
 }
 
 func (v *Codegen) genTupleLiteral(n *parser.TupleLiteral) llvm.Value {
-	panic("not done yet")
+	// TODO: Is this optimal?
+	var values []llvm.Value
+	for _, mem := range n.Members {
+		values = append(values, v.genExpr(mem))
+	}
+
+	return llvm.ConstStruct(values, false)
 }
 
 func (v *Codegen) genIntegerLiteral(n *parser.IntegerLiteral) llvm.Value {
@@ -934,9 +940,21 @@ func (v *Codegen) typeToLLVMType(typ parser.Type) llvm.Type {
 		return llvm.PointerType(v.typeToLLVMType(typ.(parser.PointerType).Addressee), 0)
 	case parser.ArrayType:
 		return v.arrayTypeToLLVMType(typ.(parser.ArrayType))
+	case *parser.TupleType:
+		return v.tupleTypeToLLVMType(typ.(*parser.TupleType))
 	default:
 		panic("Unimplemented type category in LLVM codegen")
 	}
+}
+
+func (v *Codegen) tupleTypeToLLVMType(typ *parser.TupleType) llvm.Type {
+	// TODO: Maybe move to lookup table like struct
+	var fields []llvm.Type
+	for _, mem := range typ.Members {
+		fields = append(fields, v.typeToLLVMType(mem))
+	}
+
+	return llvm.StructType(fields, false)
 }
 
 func (v *Codegen) arrayTypeToLLVMType(typ parser.ArrayType) llvm.Type {

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -681,14 +681,7 @@ func (v *BoolLiteral) NodeName() string {
 type TupleLiteral struct {
 	nodePos
 	Members []Expr
-
-	// TODO
-	// this should probably have a type for each member
-	// in the tuple, since that's what differentiates
-	// a tuple from array, after all! Till then I can't
-	// do any codegen for this, but it generates to a structure
-	// with X amount of values and their respective types.
-	Type Type
+	Type    *TupleType
 }
 
 func (v *TupleLiteral) exprNode() {}

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -836,6 +836,7 @@ const (
 	ACCESS_VARIABLE AccessType = iota // means this element is either a var on its own or the last var of a struct access
 	ACCESS_STRUCT                     // means the element is a struct being accessed
 	ACCESS_ARRAY                      // means the element is an array member being accessed, ie thing[1]
+	ACCESS_TUPLE                      // means the element is a tuple member being accessed, ie thing|1|
 )
 
 type Access struct {
@@ -843,7 +844,8 @@ type Access struct {
 	Variable     *Variable
 	variableName unresolvedName
 
-	Subscript Expr // only used with ACCESS_ARRAY
+	Subscript Expr   // only used with ACCESS_ARRAY
+	Index     uint64 // only used with ACCESS_TUPLE
 }
 
 type AccessExpr struct {
@@ -866,6 +868,9 @@ func (v *AccessExpr) GetType() Type {
 	acc := v.Accesses[len(v.Accesses)-1]
 	if acc.AccessType == ACCESS_ARRAY {
 		return acc.Variable.Type.(ArrayType).MemberType
+	}
+	if acc.AccessType == ACCESS_TUPLE {
+		return acc.Variable.Type.(*TupleType).Members[acc.Index]
 	}
 	return acc.Variable.Type
 }

--- a/parser/attr.go
+++ b/parser/attr.go
@@ -91,3 +91,30 @@ func (v *parser) parseAttrs() []*Attr {
 	}
 	return ret
 }
+
+func equalAttributes(one, other []*Attr) bool {
+	if len(one) != len(other) {
+		return false
+	}
+
+	oneMap := make(map[string]*Attr)
+	otherMap := make(map[string]*Attr)
+	for _, attr := range one {
+		oneMap[attr.Key] = attr
+	}
+	for _, attr := range other {
+		otherMap[attr.Key] = attr
+	}
+
+	for key, oneAttr := range oneMap {
+		otherAttr, ok := otherMap[key]
+		if !ok {
+			return false
+		}
+		if oneAttr.Value != otherAttr.Value {
+			return false
+		}
+	}
+
+	return true
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1377,6 +1377,31 @@ func (v *parser) parseAccessExpr() *AccessExpr {
 				if !v.tokenMatches(0, lexer.TOKEN_SEPARATOR, ".") {
 					return access
 				}
+			} else if v.tokenMatches(0, lexer.TOKEN_OPERATOR, "|") {
+				// tuple access
+				v.consumeToken()
+
+				index := v.parseNumericLiteral()
+				if index == nil {
+					v.err("Expected integer for tuple index, found `%s`", v.peek(0).Contents)
+				}
+
+				indexLit, ok := index.(*IntegerLiteral)
+				if !ok {
+					v.err("Expected integer for tuple index, found `%s`", index)
+				}
+
+				if !v.tokenMatches(0, lexer.TOKEN_OPERATOR, "|") {
+					v.err("Expected `|` after tuple index, found `%s`", v.peek(0).Contents)
+				}
+				v.consumeToken()
+
+				access.Accesses = append(access.Accesses, &Access{AccessType: ACCESS_TUPLE, variableName: name, Index: indexLit.Value})
+
+				if !v.tokenMatches(0, lexer.TOKEN_SEPARATOR, ".") {
+					return access
+				}
+
 			} else {
 				access.Accesses = append(access.Accesses, &Access{AccessType: ACCESS_VARIABLE, variableName: name})
 				return access

--- a/parser/resolve.go
+++ b/parser/resolve.go
@@ -218,8 +218,12 @@ func (v *AccessExpr) resolve(sem *semanticAnalyzer, s *Scope) {
 			v.Accesses[i+1].Variable = decl.Variable
 		case ACCESS_VARIABLE:
 			// nothing to do
+
+		case ACCESS_TUPLE:
+			// nothing to do
+
 		default:
-			panic("")
+			panic("unhandled access type")
 		}
 	}
 }

--- a/parser/semantic.go
+++ b/parser/semantic.go
@@ -712,6 +712,17 @@ func (v *AccessExpr) analyze(s *semanticAnalyzer) {
 				s.err(v, "Array subscript must be an integer type, have `%s`", access.Subscript.GetType().TypeName())
 			}
 		}
+
+		if access.AccessType == ACCESS_TUPLE {
+			tupleType, ok := access.Variable.Type.(*TupleType)
+			if !ok {
+				s.err(v, "Cannot index type `%s` as a tuple", access.Variable.Type.TypeName())
+			}
+
+			if access.Index >= uint64(len(tupleType.Members)) {
+				s.err(v, "Index `%d` (element %d) is greater than size of tuple `%s`", access.Index, access.Index+1, tupleType.TypeName())
+			}
+		}
 	}
 }
 

--- a/parser/semantic.go
+++ b/parser/semantic.go
@@ -205,7 +205,7 @@ func (v *VariableDecl) analyze(s *semanticAnalyzer) {
 
 		if v.Variable.Type == nil { // type is inferred
 			v.Variable.Type = v.Assignment.GetType()
-		} else if v.Variable.Type != v.Assignment.GetType() {
+		} else if !v.Variable.Type.Equals(v.Assignment.GetType()) {
 			s.err(v, "Cannot assign expression of type `%s` to variable of type `%s`",
 				v.Assignment.GetType().TypeName(), v.Variable.Type.TypeName())
 		}
@@ -261,7 +261,7 @@ func (v *ReturnStat) analyze(s *semanticAnalyzer) {
 		} else {
 			v.Value.setTypeHint(s.function.ReturnType)
 			v.Value.analyze(s)
-			if v.Value.GetType() != s.function.ReturnType {
+			if !v.Value.GetType().Equals(s.function.ReturnType) {
 				s.err(v.Value, "Cannot return expression of type `%s` from function `%s` of type `%s`",
 					v.Value.GetType().TypeName(), s.function.Name, s.function.ReturnType.TypeName())
 			}
@@ -588,7 +588,7 @@ func (v *ArrayLiteral) analyze(s *semanticAnalyzer) {
 		v.Type = arrayOf(v.Members[0].GetType())
 	} else {
 		for _, mem := range v.Members {
-			if mem.GetType() != memType {
+			if !mem.GetType().Equals(memType) {
 				s.err(v, "Cannot use element of type `%s` in array of type `%s`", mem.GetType().TypeName(), memType.TypeName())
 			}
 		}
@@ -604,7 +604,7 @@ func (v *ArrayLiteral) setTypeHint(t Type) {
 func (v *CastExpr) analyze(s *semanticAnalyzer) {
 	v.Expr.setTypeHint(nil)
 	v.Expr.analyze(s)
-	if v.Type == v.Expr.GetType() {
+	if v.Type.Equals(v.Expr.GetType()) {
 		s.warn(v, "Casting expression of type `%s` to the same type",
 			v.Type.TypeName())
 	} else if !v.Expr.GetType().CanCastTo(v.Type) {
@@ -766,11 +766,56 @@ func (v *SizeofExpr) setTypeHint(t Type) {
 // TupleLiteral
 
 func (v *TupleLiteral) analyze(s *semanticAnalyzer) {
-	// cba do it later
+	var memberTypes []Type
+
+	if v.Type == nil {
+		memberTypes = nil
+	} else {
+		memberTypes = v.Type.Members
+	}
+
+	if len(v.Members) == len(memberTypes) {
+		for idx, mem := range memberTypes {
+			v.Members[idx].setTypeHint(mem)
+		}
+	} else {
+		for _, mem := range v.Members {
+			mem.setTypeHint(nil)
+		}
+	}
+
+	for _, mem := range v.Members {
+		mem.analyze(s)
+	}
+
+	if v.Type == nil {
+		tuple := &TupleType{}
+		for _, mem := range v.Members {
+			if mem.GetType() == nil {
+				s.err(mem, "Couldn't infer type of tuple component")
+			}
+			tuple.addMember(mem.GetType())
+		}
+
+		v.Type = tuple
+	} else {
+		if len(v.Members) != len(memberTypes) {
+			s.err(v, "Invalid amount of entries in tuple")
+		}
+
+		for idx, mem := range v.Members {
+			if !mem.GetType().Equals(memberTypes[idx]) {
+				s.err(v, "Cannot use component of type `%s` in tuple position of type `%s`", mem.GetType().TypeName(), memberTypes[idx])
+			}
+		}
+	}
 }
 
 func (v *TupleLiteral) setTypeHint(t Type) {
-	v.Type = t
+	typ, ok := t.(*TupleType)
+	if ok {
+		v.Type = typ
+	}
 }
 
 // DefaultMatchBranch

--- a/tests/tuple_test.ark
+++ b/tests/tuple_test.ark
@@ -1,9 +1,13 @@
 func something(): |int, f32| {
     x := |4, 2.3|; // inferred
-    y: |int, f32| = |3, 2.4|;
-    return |0, 3.4|;
+    y: |int, f32| = |0, 2.4|;
+    return y;
 }
 
-func main() {
+func main(): int {
     x := something();
+    y := x|0|;
+    z := x|1|;
+
+    return y;
 }

--- a/tests/tuple_test.ark
+++ b/tests/tuple_test.ark
@@ -1,3 +1,9 @@
+func something(): |int, f32| {
+    x := |4, 2.3|; // inferred
+    y: |int, f32| = |3, 2.4|;
+    return |0, 3.4|;
+}
+
 func main() {
-    x: |int, int| = |1, 15|;
+    x := something();
 }


### PR DESCRIPTION
A major part of this commit is a move from direct comparison of types (using ==) to using a customisable function (Type.Equals()). This was neccesary to allow tuple assignment/returning without a lot of spaghetti.

The implementation of tuples themselves make the rest of the commit. The implementation is straight forward, easilier explained by the code.

Any questions?
