### PR TITLE
Implement parsing for struct function calls

### DIFF
--- a/src/parser/ast.go
+++ b/src/parser/ast.go
@@ -838,9 +838,9 @@ func (v *CastExpr) NodeName() string {
 
 type CallExpr struct {
 	nodePos
-	Function     *Function
-	functionName unresolvedName
-	Arguments    []Expr
+	Function       *Function
+	functionSource Expr
+	Arguments      []Expr
 }
 
 func (v *CallExpr) exprNode() {}

--- a/src/parser/parser.go
+++ b/src/parser/parser.go
@@ -186,7 +186,7 @@ func (v *parser) peekName() (unresolvedName, int) {
 				return name, numTok
 			}
 		} else {
-			v.err("Expected identifier, found `%s`", v.peek(0).Contents)
+			return unresolvedName{}, 0
 		}
 	}
 }
@@ -1415,7 +1415,6 @@ func (v *parser) parseAccessExpr() Expr {
 
 			lhand = &TupleAccessExpr{Tuple: lhand, Index: indexLit.Value}
 		} else {
-			// TODO: Handle function calls here
 			break
 		}
 	}
@@ -1424,16 +1423,52 @@ func (v *parser) parseAccessExpr() Expr {
 }
 
 func (v *parser) parseCallExpr() *CallExpr {
-	callExpr := &CallExpr{}
+	// this is rather dirty, please don't hit me
+	start := v.currentToken
 
-	numNameToks := 0
-	if callExpr.functionName, numNameToks = v.peekName(); v.tokenMatches(numNameToks, lexer.TOKEN_SEPARATOR, "(") && numNameToks > 0 {
-		v.consumeTokens(numNameToks)
-	} else {
+	expr := v.parseCallOrAccessExpr()
+	callExpr, ok := expr.(*CallExpr)
+	if !ok {
+		v.currentToken = start
 		return nil
 	}
 
+	return callExpr
+}
+
+func (v *parser) parseCallOrAccessExpr() Expr {
+	callExpr := &CallExpr{}
+
+	if _, numNameTokens := v.peekName(); numNameTokens <= 0 {
+		return nil
+	}
+
+	functionSrc := v.parseAccessExpr()
+	if functionSrc == nil {
+		return nil
+	}
+
+	if !v.tokenMatches(0, lexer.TOKEN_SEPARATOR, "(") {
+		tok := v.peek(0)
+		log.Debugln("parser", "[%s:%d:%d] `%s` (type `%s`)", tok.Filename, tok.LineNumber, tok.CharNumber, tok.Contents, tok.Type)
+		return functionSrc
+	}
 	v.consumeToken() // consume (
+
+	// TODO: This will be cleaner once we get around to implementing function types
+	switch functionSrc.(type) {
+	case *VariableAccessExpr:
+		vae := functionSrc.(*VariableAccessExpr)
+		callExpr.functionName = vae.Name
+
+	case *StructAccessExpr:
+		sae := functionSrc.(*StructAccessExpr)
+		name := unresolvedName{name: sae.GetType().TypeName() + "." + sae.Member}
+		callExpr.functionName = name
+
+	default:
+		panic("Invalid function source (for now)")
+	}
 
 	if v.tokenMatches(0, lexer.TOKEN_SEPARATOR, ")") {
 		v.consumeToken()

--- a/src/parser/parser.go
+++ b/src/parser/parser.go
@@ -1455,20 +1455,7 @@ func (v *parser) parseCallOrAccessExpr() Expr {
 	}
 	v.consumeToken() // consume (
 
-	// TODO: This will be cleaner once we get around to implementing function types
-	switch functionSrc.(type) {
-	case *VariableAccessExpr:
-		vae := functionSrc.(*VariableAccessExpr)
-		callExpr.functionName = vae.Name
-
-	case *StructAccessExpr:
-		sae := functionSrc.(*StructAccessExpr)
-		name := unresolvedName{name: sae.GetType().TypeName() + "." + sae.Member}
-		callExpr.functionName = name
-
-	default:
-		panic("Invalid function source (for now)")
-	}
+	callExpr.functionSource = functionSrc
 
 	if v.tokenMatches(0, lexer.TOKEN_SEPARATOR, ")") {
 		v.consumeToken()


### PR DESCRIPTION
Currently struct functions will target the name "TypeName.FunctionName".
This can of course be changed at a later time.

Opens up for impl codegen.
