### PR TITLE
Revert "Re-add pipe syntax for tuples"

### DIFF
--- a/src/codegen/LLVMCodegen/codegen.go
+++ b/src/codegen/LLVMCodegen/codegen.go
@@ -739,15 +739,13 @@ func (v *Codegen) genArrayLiteral(n *parser.ArrayLiteral) llvm.Value {
 }
 
 func (v *Codegen) genTupleLiteral(n *parser.TupleLiteral) llvm.Value {
-	alloc := v.builder.CreateAlloca(v.typeToLLVMType(n.GetType()), "")
-
-	for idx, mem := range n.Members {
-		index := llvm.ConstInt(llvm.IntType(32), uint64(idx), false)
-		gep := v.builder.CreateGEP(alloc, []llvm.Value{llvm.ConstInt(llvm.IntType(32), 0, false), index}, "")
-		v.builder.CreateStore(v.genExpr(mem), gep)
+	// TODO: Is this optimal?
+	var values []llvm.Value
+	for _, mem := range n.Members {
+		values = append(values, v.genExpr(mem))
 	}
 
-	return v.builder.CreateLoad(alloc, "")
+	return llvm.ConstStruct(values, false)
 }
 
 func (v *Codegen) genNumericLiteral(n *parser.NumericLiteral) llvm.Value {

--- a/src/lexer/lexer.go
+++ b/src/lexer/lexer.go
@@ -293,9 +293,6 @@ func (v *lexer) recognizeOperatorToken() {
 	// treat them as individual operators instead.
 	if v.peek(0) == ':' && v.peek(1) == '=' {
 		v.consume()
-	} else if v.peek(0) == '|' {
-		// split consecutive pipes to allow for pipe tuples
-		v.consume()
 	} else {
 		v.consume()
 		if isOperator(v.peek(0)) && v.peek(0) != '^' {

--- a/src/parser/constructor.go
+++ b/src/parser/constructor.go
@@ -543,6 +543,9 @@ func (v *TupleLiteralNode) construct(c *Constructor) Expr {
 	for _, member := range v.Values {
 		res.Members = append(res.Members, c.constructExpr(member))
 	}
+	if len(res.Members) == 1 {
+		return res.Members[0]
+	}
 	res.setPos(v.Where().Start())
 	return res
 }

--- a/src/parser/parser.go
+++ b/src/parser/parser.go
@@ -1021,7 +1021,7 @@ func (v *parser) parseType() ParseNode {
 	var res ParseNode
 	if v.tokenMatches(0, lexer.TOKEN_OPERATOR, "^") {
 		res = v.parsePointerType()
-	} else if v.tokenMatches(0, lexer.TOKEN_OPERATOR, "|") {
+	} else if v.tokenMatches(0, lexer.TOKEN_SEPARATOR, "(") {
 		res = v.parseTupleType()
 	} else if v.tokenMatches(0, lexer.TOKEN_SEPARATOR, "[") {
 		res = v.parseArrayType()
@@ -1050,8 +1050,7 @@ func (v *parser) parsePointerType() *PointerTypeNode {
 }
 
 func (v *parser) parseTupleType() *TupleTypeNode {
-	if !v.tokenMatches(0, lexer.TOKEN_OPERATOR, "|") {
-		println(v.peek(0))
+	if !v.tokenMatches(0, lexer.TOKEN_SEPARATOR, "(") {
 		return nil
 	}
 	startToken := v.consumeToken()
@@ -1070,7 +1069,7 @@ func (v *parser) parseTupleType() *TupleTypeNode {
 		v.consumeToken()
 	}
 
-	if !v.tokenMatches(0, lexer.TOKEN_OPERATOR, "|") {
+	if !v.tokenMatches(0, lexer.TOKEN_SEPARATOR, ")") {
 		v.err("Expected closing `)` after tuple type, got `%s`", v.peek(0).Contents)
 	}
 	endToken := v.consumeToken()
@@ -1149,24 +1148,11 @@ func (v *parser) parseBinaryOperator(upperPrecedence int, lhand ParseNode) Parse
 			return lhand
 		}
 
-		// ugh, jank
-		op := v.peek(0).Contents
-		if op == "|" {
-			if v.peek(1).Contents == "|" {
-				op += "|"
-			}
-		}
-
-		typ := stringToBinOpType(op)
+		typ := stringToBinOpType(v.peek(0).Contents)
 		if typ == BINOP_ERR {
 			v.err("Invalid binary operator `%s`", v.peek(0).Contents)
 		}
 		v.consumeToken()
-
-		// ugh, jank
-		if op == "||" {
-			v.consumeToken()
-		}
 
 		rhand := v.parsePrimaryExpr()
 		if rhand == nil {
@@ -1194,16 +1180,12 @@ func (v *parser) parseBinaryOperator(upperPrecedence int, lhand ParseNode) Parse
 }
 
 func (v *parser) parsePrimaryExpr() ParseNode {
-	// Main problem with enums is that the current propesed syntax for enums conflict
-	// (parsing wise) with function calls.
 	var res ParseNode
 
 	if sizeofExpr := v.parseSizeofExpr(); sizeofExpr != nil {
 		res = sizeofExpr
 	} else if addrofExpr := v.parseAddrofExpr(); addrofExpr != nil {
 		res = addrofExpr
-	} else if parensExpr := v.parseParensExpr(); parensExpr != nil {
-		res = parensExpr
 	} else if litExpr := v.parseLitExpr(); litExpr != nil {
 		res = litExpr
 	} else if castExpr := v.parseCastExpr(); castExpr != nil {
@@ -1259,25 +1241,6 @@ func (v *parser) parseAddrofExpr() *AddrofExprNode {
 	res := &AddrofExprNode{Value: value}
 	res.SetWhere(lexer.NewSpan(startToken.Where.Start(), value.Where().End()))
 	return res
-}
-
-func (v *parser) parseParensExpr() ParseNode {
-	if !v.tokenMatches(0, lexer.TOKEN_SEPARATOR, "(") {
-		return nil
-	}
-	v.consumeToken()
-
-	subExpr := v.parseExpr()
-	if subExpr == nil {
-		v.err("Expected valid expression in parens expression")
-	}
-
-	if !v.tokenMatches(0, lexer.TOKEN_SEPARATOR, ")") {
-		v.err("Expected closing `)` in parens expression, got `%s`", v.peek(0).Contents)
-	}
-	v.consumeToken()
-
-	return subExpr
 }
 
 func (v *parser) parseLitExpr() ParseNode {
@@ -1446,22 +1409,11 @@ func (v *parser) parseAccessExpr() ParseNode {
 			res.SetWhere(lexer.NewSpan(lhand.Where().Start(), endToken.Where.End()))
 			lhand = res
 		} else if v.tokenMatches(0, lexer.TOKEN_OPERATOR, "|") {
-			if v.peek(1).Type != lexer.TOKEN_NUMBER {
-				break
-			}
-
 			// tuple access
 			v.consumeToken()
 
-			log.Debugln("parser", "Before number parse: %s", v.peek(0).Contents)
-			log.Debug("parser", v.input.MarkSpan(v.peek(0).Where))
-			log.Debug("parser", v.input.MarkPos(v.peek(0).Where.Start()))
 			index := v.parseNumberLit()
 			if index == nil || index.IsFloat {
-				println(index)
-				log.Debugln("parser", "After invalid number parse: %s", v.peek(0).Contents)
-				log.Debug("parser", v.input.MarkSpan(v.peek(0).Where))
-				log.Debug("parser", v.input.MarkPos(v.peek(0).Where.Start()))
 				v.err("Expected integer for tuple index")
 			}
 
@@ -1516,13 +1468,17 @@ func (v *parser) parseArrayLit() *ArrayLiteralNode {
 }
 
 func (v *parser) parseTupleLit() *TupleLiteralNode {
-	if !v.tokenMatches(0, lexer.TOKEN_OPERATOR, "|") {
+	if !v.tokenMatches(0, lexer.TOKEN_SEPARATOR, "(") {
 		return nil
 	}
 	startToken := v.consumeToken()
 
 	var values []ParseNode
 	for {
+		if v.tokenMatches(0, lexer.TOKEN_SEPARATOR, ")") {
+			break
+		}
+
 		value := v.parseExpr()
 		if value == nil {
 			v.err("Expected valid expression in tuple literal")
@@ -1535,8 +1491,8 @@ func (v *parser) parseTupleLit() *TupleLiteralNode {
 		v.consumeToken()
 	}
 
-	if !v.tokenMatches(0, lexer.TOKEN_OPERATOR, "|") {
-		v.err("Expected closing `|` after tuple literal, got `%s`", v.peek(0).Contents)
+	if !v.tokenMatches(0, lexer.TOKEN_SEPARATOR, ")") {
+		v.err("Expected closing `]` after tuple literal, got `%s`", v.peek(0).Contents)
 	}
 	endToken := v.consumeToken()
 

--- a/src/parser/type.go
+++ b/src/parser/type.go
@@ -417,6 +417,9 @@ func (v PointerType) Equals(t Type) bool {
 // TupleType
 
 func tupleOf(types ...Type) Type {
+	if len(types) == 1 {
+		return types[0]
+	}
 	return &TupleType{Members: types}
 }
 

--- a/tests/enum_union_test.ark
+++ b/tests/enum_union_test.ark
@@ -1,6 +1,6 @@
 enum Option {
 	None,
-	Some|^void|
+	Some(^void)
 }
 
 func main(): int {

--- a/tests/tuple_test.ark
+++ b/tests/tuple_test.ark
@@ -1,26 +1,17 @@
 [c] func printf(fmt: str, ...): int;
 
-func something(): |int, f32| {
-    [unused] x := |4, 2.3|; // inferred
-    y: |int, f32| = |0, 2.4|;
+func something(): (int, f32) {
+    [unused] x := (4, 2.3); // inferred
+    y: (int, f32) = (0, 2.4);
     return y;
 }
 
-func ambigous(): ||int, f32|, bool| {    
-    x := something();
-    return ||x|0|, x|1||, false|;
-}
-
 func main(): int {
-    a := ambigous();
-    x := a|0|;
+    x := something();
     y := x|0|;
     [unused] z := x|1|;
 
-    if !a|1| {
-    	C::printf("%d %f\n", x|0|, x|1|);
-    	return y;
-    }
+    C::printf("%d %f\n", x|0|, x|1|);
 
-    return 1;
+    return y;
 }


### PR DESCRIPTION
Reverts ark-lang/ark#547

It really feels weird when actually using pipes. Plus the collision with calling syntax for enums now simply collide with indexing syntax. I'd rather special case the first.
