### PR TITLE
Update build instructions in README to reflect new dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,18 @@ you get started:
 Replace `RELEASE_360` with the version of LLVM you have installed. For example, version 3.6.1 becomes `RELEASE_361`. You can find out your version of llvm by running `llvm-config --version`.
 
     $ svn co https://llvm.org/svn/llvm-project/llvm/tags/RELEASE_360/final \
-    > $GOPATH/src/llvm.org/llvm
+        $GOPATH/src/llvm.org/llvm
     $ export CGO_CPPFLAGS="`llvm-config --cppflags`"
     $ export CGO_LDFLAGS="`llvm-config --ldflags --libs --system-libs all`"
     $ export CGO_CXXFLAGS=-std=c++11
     $ go install -tags byollvm llvm.org/llvm/bindings/go/llvm
+    $ go get github.com/russross/blackfriday
+    $ go get gopkg.in/alecthomas/kingpin.v2
     $ go get github.com/ark-lang/ark
-    $ go install github.com/ark-lang/ark
+    $ cd $GOPATH/github.com/ark-lang/ark
+    $ make
 
-Make sure `$GOPATH/bin` is in your `$PATH`.
+The `ark` binary will be built in `$GOPATH/bin`. To use the compiler, make sure `$GOPATH/bin` is in your `$PATH`.
 
 To see the current state of the compiler, try running the [test script](#testing).
 


### PR DESCRIPTION
In addition to reflecting the new dependencies, this pull request fixes these things:
- the `>` in the build instructions could be interpreted as redirecting to a file; replaced it with spaces
- the README didn’t explicitly state that the location of the output binary.
