### PR TITLE
Minor syntax changes

### DIFF
--- a/examples/factorial.ark
+++ b/examples/factorial.ark
@@ -1,14 +1,14 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 [c] func scanf(fmt: str, ...);
 
-func factorial(n: int): int {
+func factorial(n: int) -> int {
     if n == 0 {
         return 1;
     }
     return n * factorial(n - 1);
 }
 
-func main(): int {
+func main() -> int {
     number: int = 1;
     C::printf("Enter a number: \n");
     C::scanf("%d", &number);

--- a/examples/higher_or_lower.ark
+++ b/examples/higher_or_lower.ark
@@ -1,12 +1,12 @@
 [c] func printf(fmt: str, ...);
-[c] func rand(): int;
+[c] func rand() -> int;
 [c] func srand(i: uint);
-[c] func time(ptr: u32): u64;
+[c] func time(ptr: u32) -> u64;
 [c] func scanf(fmt: str, ...);
 
-func println(mess: str) -> C::printf("%s\n", mess);
+func println(mess: str) => C::printf("%s\n", mess);
 
-func main(): int {
+func main() -> int {
     println("Higher or lower game, in Ark!");
 
     C::srand(uint(C::time(0)));

--- a/examples/pi_monte_carlo.ark
+++ b/examples/pi_monte_carlo.ark
@@ -1,16 +1,16 @@
 [c] func printf(fmt: str, ...);
 [c] func srand(seed: uint);
-[c] func time(ptr: u64): uint;
-[c] func rand(): int;
-[c] func sqrt(in: f64): f64;
+[c] func time(ptr: u64) -> uint;
+[c] func rand() -> int;
+[c] func sqrt(in: f64) -> f64;
 
-func randFloat(): f64 {
+func randFloat() -> f64 {
     RAND_MAX := 2147483647; // hack for now
 
     return f64(C::rand()) / f64(RAND_MAX);
 }
 
-func calculate(iters: int): f64 {
+func calculate(iters: int) -> f64 {
     radius: f64 = 10.0;
     width := radius * 2.0;
 
@@ -31,7 +31,7 @@ func calculate(iters: int): f64 {
     return 4.0 * f64(totalInCircle) / f64(iters);
 }
 
-func main(): int {
+func main() -> int {
     C::srand(C::time(0));
 
     iters := 20000000;

--- a/examples/prime.ark
+++ b/examples/prime.ark
@@ -20,10 +20,10 @@ Close! We had no optimization passes either!
 
 **/
 
-[c] func printf(fmt: str, ...): int;
-[c] func sqrt(x: f64): f64;
+[c] func printf(fmt: str, ...) -> int;
+[c] func sqrt(x: f64) -> f64;
 
-func is_prime(n: int): int {
+func is_prime(n: int) -> int {
     if n < 2 {
         return 0;
     } else if n == 2 {
@@ -45,7 +45,7 @@ func is_prime(n: int): int {
     return i;
 }
 
-func main(): int {
+func main() -> int {
     mut no_primes: int = 0;
     limit: int = 67108864;
     mut n: int = 0;

--- a/src/parser/parser.go
+++ b/src/parser/parser.go
@@ -333,7 +333,7 @@ func (v *parser) parseFuncDecl() *FunctionDeclNode {
 	var body *BlockNode
 	var stat, expr ParseNode
 	var endPosition lexer.Position
-	if v.tokenMatches(0, lexer.TOKEN_OPERATOR, "->") {
+	if v.tokenMatches(0, lexer.TOKEN_OPERATOR, "=>") {
 		v.consumeToken()
 
 		if stat = v.parseStat(); stat != nil {
@@ -342,7 +342,7 @@ func (v *parser) parseFuncDecl() *FunctionDeclNode {
 			tok := v.expect(lexer.TOKEN_SEPARATOR, ";")
 			endPosition = tok.Where.End()
 		} else {
-			v.err("Expected valid statement or expression after `->` in function declaration")
+			v.err("Expected valid statement or expression after `=>` in function declaration")
 		}
 	} else {
 		body = v.parseBlock()
@@ -431,7 +431,7 @@ func (v *parser) parseFuncHeader() *FunctionHeaderNode {
 	maybeEndToken := v.expect(lexer.TOKEN_SEPARATOR, ")")
 
 	var returnType ParseNode
-	if v.tokenMatches(0, lexer.TOKEN_OPERATOR, ":") {
+	if v.tokenMatches(0, lexer.TOKEN_OPERATOR, "->") {
 		v.consumeToken()
 
 		returnType = v.parseType(true)

--- a/src/parser/parser.go
+++ b/src/parser/parser.go
@@ -436,7 +436,7 @@ func (v *parser) parseFuncHeader() *FunctionHeaderNode {
 
 		returnType = v.parseType(true)
 		if returnType == nil {
-			v.err("Expected valid type after `:` in function header")
+			v.err("Expected valid type after `->` in function header")
 		}
 	}
 
@@ -812,7 +812,7 @@ func (v *parser) parseMatchStat() *MatchStatNode {
 			v.err("Expected valid expression as pattern in match statement")
 		}
 
-		v.expect(lexer.TOKEN_OPERATOR, "->")
+		v.expect(lexer.TOKEN_OPERATOR, "=>")
 
 		body := v.parseStat()
 		if body == nil {

--- a/tests/args_test.ark
+++ b/tests/args_test.ark
@@ -1,6 +1,6 @@
 [c] func printf(fmt: str, ...);
 
-func main(argc: int, argv: ^str): int {
+func main(argc: int, argv: ^str) -> int {
     C::printf("%d %s\n", argc, ^argv);
 
     return 0;

--- a/tests/arrays/array_global_test.ark
+++ b/tests/arrays/array_global_test.ark
@@ -1,9 +1,9 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
 mut arrayGlobalTest: []s16 = [100, 101, 102, 103, 104];
 random := [0, 16, 32, 64, 128, 256, 512, 1024];
 
-func main(): int {
+func main() -> int {
     if arrayGlobalTest[1] != 101 {
         return 1;
     }

--- a/tests/arrays/array_test.ark
+++ b/tests/arrays/array_test.ark
@@ -1,6 +1,6 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
-func main(): int {
+func main() -> int {
     mut arrayLitTest: []s16 = [100, 101, 102, 103, 104];
 
     if arrayLitTest[1] != 101 {

--- a/tests/assign_test.ark
+++ b/tests/assign_test.ark
@@ -1,4 +1,4 @@
-func main(): int {
+func main() -> int {
     mut x: int = 5;
     x = 10;
     return x - 10;

--- a/tests/binop_assign_test.ark
+++ b/tests/binop_assign_test.ark
@@ -1,13 +1,13 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
 mut glob: int = 5;
 
-func getGlob(): ^int {
+func getGlob() -> ^int {
 	glob += 1;
 	return &glob;
 }
 
-func main(): int {
+func main() -> int {
 	mut x := 0;
 	x += 5;
 

--- a/tests/bool_test.ark
+++ b/tests/bool_test.ark
@@ -1,4 +1,4 @@
-func main(): int {
+func main() -> int {
     trueTest := true;
     falseTest: bool = false;
 

--- a/tests/c_ints_test.ark
+++ b/tests/c_ints_test.ark
@@ -1,5 +1,5 @@
-[c] func printf(fmt: str, ...): int;
-[c] func malloc(size: uint): ^void;
+[c] func printf(fmt: str, ...) -> int;
+[c] func malloc(size: uint) -> ^void;
 [c] func free(ptr: ^void);
 
 type Test struct {
@@ -9,7 +9,7 @@ type Test struct {
     b: int = 4
 };
 
-func main(): int {
+func main() -> int {
 	x: C::uint = 0;
 	y: C::int = 0;
 	z: uint = 0;

--- a/tests/cast_call_ambiguity_test.ark
+++ b/tests/cast_call_ambiguity_test.ark
@@ -1,8 +1,8 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
 glob: int = 5;
 
-func getGlob(): ^int {
+func getGlob() -> ^int {
     return ^int(&glob);
 }
 
@@ -11,7 +11,7 @@ func printGlob() {
     C::printf("%d\n", ^(getGlob()));
 }
 
-func main(): int {
+func main() -> int {
 	printGlob();
 	return 0;
 }

--- a/tests/cast_test.ark
+++ b/tests/cast_test.ark
@@ -1,6 +1,6 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
-func main(): int {
+func main() -> int {
     a: int = 0;
     C::printf("%f\n", f32(a));
 

--- a/tests/default_test.ark
+++ b/tests/default_test.ark
@@ -1,5 +1,5 @@
-[c] func printf(fmt: str, ...): int;
-[c] func malloc(size: uint): ^void;
+[c] func printf(fmt: str, ...) -> int;
+[c] func malloc(size: uint) -> ^void;
 [c] func free(ptr: ^void);
 
 type Test struct {
@@ -9,7 +9,7 @@ type Test struct {
     b: int = 4
 };
 
-func main(): int {
+func main() -> int {
 	x := default(int);
 	y := default(bool);
 

--- a/tests/defer_test.ark
+++ b/tests/defer_test.ark
@@ -1,10 +1,10 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
 func println(mess: str) {
     C::printf("%s\n", mess);
 }
 
-func main(): int {
+func main() -> int {
     defer println("printed last");
     defer println("printed second-to-last");
 

--- a/tests/deref_test.ark
+++ b/tests/deref_test.ark
@@ -1,6 +1,6 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
-func main(): int {
+func main() -> int {
     mut x := 9;
     y := &x;
 

--- a/tests/enum_test.ark
+++ b/tests/enum_test.ark
@@ -4,7 +4,7 @@ type Test enum {
 	GG,
 };
 
-func main(): int {
+func main() -> int {
 	x := Test::VALUE;
 	y := Test::ANOTHER;
 	z := Test::GG;

--- a/tests/enum_union_test.ark
+++ b/tests/enum_union_test.ark
@@ -1,11 +1,11 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
 type Tree enum {
     Node{left: ^Tree, right: ^Tree},
     Leaf(int)
 };
 
-func main(): int {
+func main() -> int {
 	x := Tree::Leaf(42);
 	y := Tree::Leaf(36);
 	z := Tree::Node{left: &x, right: &y};

--- a/tests/fibonacci_test.ark
+++ b/tests/fibonacci_test.ark
@@ -1,13 +1,13 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
-func fib(n: int): int {
+func fib(n: int) -> int {
     if n < 2 {
         return n;
     }
     return fib(n - 1) + fib(n - 2);
 }
 
-func main(): int {
+func main() -> int {
     C::printf("fib(12) == %d\n", fib(12));
 
     return 0;

--- a/tests/fizzbuzz_test.ark
+++ b/tests/fizzbuzz_test.ark
@@ -2,10 +2,10 @@
 // %3 -> Fizz
 // %5 -> Buzz
 
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 [c] func putchar(c: s8);
 
-func main(): int {
+func main() -> int {
     mut i := 1;
 
     for i <= 100 {

--- a/tests/float_suffix_test.ark
+++ b/tests/float_suffix_test.ark
@@ -1,6 +1,6 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
-func main(): int {
+func main() -> int {
     t1: f64 = 10f;
     t2: f64 = 0.4d;
     [unused] t3: f64 = 1214.935735q;

--- a/tests/for_conditional_test.ark
+++ b/tests/for_conditional_test.ark
@@ -1,6 +1,6 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
-func main(): int {
+func main() -> int {
     mut x := 2;
     mut y := 2;
     for x == 2 {

--- a/tests/for_test.ark
+++ b/tests/for_test.ark
@@ -1,6 +1,6 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
-func main(): int {
+func main() -> int {
     mut i := 0;
 
     for i < 5 {

--- a/tests/func_test.ark
+++ b/tests/func_test.ark
@@ -1,4 +1,4 @@
-func add(a: int, b: int): int {
+func add(a: int, b: int) -> int {
     return a + b;
 }
 
@@ -6,7 +6,7 @@ func this_is_void(swag: int) {
     [unused] x := swag;
 }
 
-func main(): int {
+func main() -> int {
     [unused] x: int = 5;
     [unused] z: int = add(5, 10);
     [unused] y: int = 19 - 25;

--- a/tests/generic_test.ark
+++ b/tests/generic_test.ark
@@ -1,18 +1,18 @@
-[c] func printf(fmt: str, ...): int;
-[c] func malloc(size: uint): ^void;
+[c] func printf(fmt: str, ...) -> int;
+[c] func malloc(size: uint) -> ^void;
 
 type Option<T> enum {
     None,
     Some(int)
 };
 
-func alloc<T>(): ^int {
+func alloc<T>() -> ^int {
     ptr := C::malloc(sizeof(int));
     // ... // Check allocation success
     return ^int(ptr);
 }
 
-func main(): int {
+func main() -> int {
 	a: int = 0;
 	x := Option::None<int>;
 	y := Option::Some(a);

--- a/tests/global_test.ark
+++ b/tests/global_test.ark
@@ -1,8 +1,8 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
 mut x: int = 10;
 
-func main(): int {
+func main() -> int {
     x = 20;
     C::printf("%d\n", x);
     return 0;

--- a/tests/if_test.ark
+++ b/tests/if_test.ark
@@ -1,6 +1,6 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
-func main(): int {
+func main() -> int {
 	mut x: int = 5;
 	if x == 5 {
 		C::printf("this is a test\n");

--- a/tests/main_test.ark
+++ b/tests/main_test.ark
@@ -1,3 +1,3 @@
-func main(): int {
+func main() -> int {
     return 0;
 }

--- a/tests/match_test.ark
+++ b/tests/match_test.ark
@@ -1,6 +1,6 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
-func main(): int {
+func main() -> int {
     valid: bool = true;
 
     match valid {

--- a/tests/match_test.ark
+++ b/tests/match_test.ark
@@ -4,19 +4,19 @@ func main() -> int {
     valid: bool = true;
 
     match valid {
-        true -> C::printf("%s\n", "true");
-        false -> C::printf("%s\n", "false");
+        true => C::printf("%s\n", "true");
+        false => C::printf("%s\n", "false");
     }
 
 
     foo := "bar";
 
     match foo {
-        "hello" -> C::printf("foo matches hello");
-        "world" -> { }
-        "bar" -> { award := "baz";
+        "hello" => C::printf("foo matches hello");
+        "world" => { }
+        "bar" => { award := "baz";
             C::printf("correct! you win %s\n", award); }
-        _ -> C::printf("default\n");
+        _ => C::printf("default\n");
     }
 
     return 0;

--- a/tests/method_test.ark
+++ b/tests/method_test.ark
@@ -1,4 +1,4 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
 type Thing struct {
     x: int
@@ -18,7 +18,7 @@ func (v: Thing2) do() {
     C::printf("did, from an int!\n");
 }
 
-func main(): int {
+func main() -> int {
     mut thing: Thing;
     thing.x = 6;
 

--- a/tests/named_types_test.ark
+++ b/tests/named_types_test.ark
@@ -1,4 +1,4 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
 type thing int;
 type thing2 thing;
@@ -11,7 +11,7 @@ type structType struct {
     x: int
 };
 
-func main(): int {
+func main() -> int {
     C::printf("Named types test.\n");
 
     // primitive test

--- a/tests/nested_comment_test.ark
+++ b/tests/nested_comment_test.ark
@@ -5,6 +5,6 @@
   */
 */
 
-func main(): int {
+func main() -> int {
 	return 0;
 }

--- a/tests/nested_scope_test.ark
+++ b/tests/nested_scope_test.ark
@@ -1,6 +1,6 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
-func main(): int {
+func main() -> int {
     mut x: int = 5;
 
     {

--- a/tests/novoid_test.ark
+++ b/tests/novoid_test.ark
@@ -1,10 +1,10 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
 func say_hi() {
     C::printf("hi\n");
 }
 
-func main(): int {
+func main() -> int {
     say_hi();
     return 0;
 }

--- a/tests/ownership_test.ark
+++ b/tests/ownership_test.ark
@@ -1,15 +1,15 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
 type Test struct {
     a: int,
 };
 
-func do_stuff(mut a: int): int {
+func do_stuff(mut a: int) -> int {
     a = 21;
     return a;
 }
 
-func main(): int {
+func main() -> int {
     mut test: Test;
     test.a = 32;
     test.a = do_stuff(test.a);

--- a/tests/pointer_test.ark
+++ b/tests/pointer_test.ark
@@ -1,4 +1,4 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
 func swap(mut a: ^s32, mut b: ^s32) 
 {
@@ -7,7 +7,7 @@ func swap(mut a: ^s32, mut b: ^s32)
    ^b = temp;
 }
 
-func main(): int 
+func main() -> int 
 {
     a: s32 = 5;
     b: s32 = 6;

--- a/tests/prime_sieve_test.ark
+++ b/tests/prime_sieve_test.ark
@@ -1,6 +1,6 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
-func main(): int {
+func main() -> int {
 	// oh god the horror
 	mut primes: []bool = [
 		false, true, true, true, true, true, true, true, true, true,

--- a/tests/prototype_test.ark
+++ b/tests/prototype_test.ark
@@ -1,6 +1,6 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
-func main(): int {
+func main() -> int {
     C::printf("finally, it fucking works!\n");
     C::printf("we have to specify the c attribute so it doesn't mangle the name %d\n", 5);
     puts("test fast calling convention\n");

--- a/tests/scanf_test_requiresinput.ark
+++ b/tests/scanf_test_requiresinput.ark
@@ -1,7 +1,7 @@
-[c] func scanf(fmt: str, ...): int;
-[c] func printf(fmt: str, ...): int;
+[c] func scanf(fmt: str, ...) -> int;
+[c] func printf(fmt: str, ...) -> int;
 
-func main(): int {
+func main() -> int {
     mut x: s32 = 0;
 
     C::printf("Input a number: ");

--- a/tests/single_stat_func_test.ark
+++ b/tests/single_stat_func_test.ark
@@ -1,15 +1,15 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
-[unused] func add(a: int, b: int): int -> a + b;
+[unused] func add(a: int, b: int) -> int => a + b;
 
-func test(mut a: int) -> for a < 10 {
+func test(mut a: int) => for a < 10 {
     C::printf("this is a test %d\n", a);
     a = a + 1;
 }
 
-func whatever() -> C::printf("testing the whatever() func\n");
+func whatever() => C::printf("testing the whatever() func\n");
 
-func main(): int {
+func main() -> int {
     whatever();
     z: int = 0;
     test(z);

--- a/tests/sizeof_test.ark
+++ b/tests/sizeof_test.ark
@@ -1,4 +1,4 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
 type Test struct {
     x: int,
@@ -7,7 +7,7 @@ type Test struct {
     b: int
 };
 
-func main(): int {
+func main() -> int {
     i: int = 0;
     C::printf("sizeof i: %d\n", sizeof(i));
     C::printf("sizeof &i: %d\n", sizeof(&i));

--- a/tests/struct_default_test.ark
+++ b/tests/struct_default_test.ark
@@ -1,4 +1,4 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
 type Test struct {
     x: int = 1,
@@ -7,7 +7,7 @@ type Test struct {
     b: int = 4
 };
 
-func main(): int {
+func main() -> int {
     // To create without defaults -> t: Test = {};
 	t := default(Test);
 

--- a/tests/struct_test.ark
+++ b/tests/struct_test.ark
@@ -1,10 +1,10 @@
 type EmptyStruct struct {};
 
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
 mut thing: Test = {z: 42};
 
-func main(): int {
+func main() -> int {
     C::printf("thing.z: %f\n", thing.z);
     if thing.z != 42 {
         return 1;

--- a/tests/trait.ark
+++ b/tests/trait.ark
@@ -1,7 +1,7 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
 trait ToString {
-    func toString(): str;
+    func toString() -> str;
 }
 
 struct Foo {
@@ -20,7 +20,7 @@ impl Foo for ToString {
     }
 }
 
-func main(): int {
+func main() -> int {
     mut thing: Foo;
 
     return 0;

--- a/tests/tuple_test.ark
+++ b/tests/tuple_test.ark
@@ -1,12 +1,12 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
-func something(): (int, f32) {
+func something() -> (int, f32) {
     [unused] x := (4, 2.3); // inferred
     y: (int, f32) = (0, 2.4);
     return y;
 }
 
-func main(): int {
+func main() -> int {
     x := something();
     y := x|0|;
     [unused] z := x|1|;

--- a/tests/unused_func.ark
+++ b/tests/unused_func.ark
@@ -2,7 +2,7 @@ func add() {
 
 }
 
-func main(): int {
+func main() -> int {
     add();
     return 0;
 }

--- a/tests/unused_var.ark
+++ b/tests/unused_var.ark
@@ -2,7 +2,7 @@ func printf(y: int) {
 
 }
 
-func main(): int {
+func main() -> int {
     mut x: int = 0;
 
     y := x + x;

--- a/tests/variadic_test.ark
+++ b/tests/variadic_test.ark
@@ -1,6 +1,6 @@
-[c] func printf(fmt: str, ...): int;
+[c] func printf(fmt: str, ...) -> int;
 
-func main(): int {
+func main() -> int {
     C::printf("hi");
     return 0;
 }


### PR DESCRIPTION
Well, technically it's a large syntax change considering how much it's used. Anyhow, functions now have arrows instead of colons before their return type, and also single line functions have been changed from `->` to `=>`, as have match arms.
