### PR TITLE
[WIP] few borrow semantics

### DIFF
--- a/src/semantic/borrow.go
+++ b/src/semantic/borrow.go
@@ -77,12 +77,15 @@ func (v *BorrowCheck) CheckVariableAccessExpr(s *SemanticAnalyzer, n *parser.Var
 				variable.Ownership = false
 			}
 		}
-	} else if v.addrofExpr != nil {
+	} else if v.addrofExpr != nil && v.callExpr == nil {
 		// this is the variable that is being borrowed!
+		// note this only borrows for actual references
+		// not stuff like a function call
 		if variable, ok := v.currentLifetime.resources[mangledName]; ok {
 			variable.Borrowed = true
 		}
 	} else {
+		// creates a new resource
 		if variable, ok := v.currentLifetime.resources[mangledName]; ok {
 			if !variable.Ownership {
 				s.Err(n, "use of moved value %s", n.Variable.Name)
@@ -219,7 +222,9 @@ func (v *BorrowCheck) destroyLifetime(s *SemanticAnalyzer) {
 
 	for _, key := range v.currentLifetime.resourceKeys {
 		if res, ok := v.currentLifetime.resources[key]; ok {
-			// I think this would work??
+			// this is a hack, and I don't think this will
+			// scale well or at all, but we'll cross that
+			// bridge when it fucks me over...
 			res.Borrowed = false
 
 			fmt.Println("removing resource " + res.Name + " from lifetime " + v.currentLifetime.name)

--- a/test.py
+++ b/test.py
@@ -90,7 +90,7 @@ for directory, filelist in dirs:
 		if show_output:
 			print(bold("Compiling ") + name + "...")
 
-		cmd = ["ark", "build", "-b", directory]
+		cmd = ["ark", "build", "-b", directory, "--unused"]
 		if be_verbose:
 			cmd.append("-v")
 		cmd.extend([name.replace(".ark", ""), "-o", "tests/"+output_file])

--- a/tests/borrow_test.ark
+++ b/tests/borrow_test.ark
@@ -7,6 +7,7 @@ func move_something(a: int) {
 func main() -> int { // B
     x: int = 10;
     move_something(x);
+
     move_something(x);
 
     { // C

--- a/tests/borrow_test.ark
+++ b/tests/borrow_test.ark
@@ -1,23 +1,20 @@
 [c] func printf(fmt: str, ...) -> int; // A
 
+func dont_move(a: &int) {
+
+}
+
 func move_something(a: int) {
 
 }
 
+func move_return_ownership(a: int) -> int{
+    return a;
+}
+
 func main() -> int { // B
-    x: int = 10;
-    move_something(x);
-
-    move_something(x);
-
-    { // C
-        z: int = 30;
-        [unused] e: &int = &z;
-        { // D
-            [unused] b: int = 32;
-        }
-    }
-    [unused] y: &int = &x;
-
+    mut x: int = 10;
+    dont_move(&x);
+    C::printf("x is %d\n", x);
     return 0;
 }

--- a/tests/borrow_test.ark
+++ b/tests/borrow_test.ark
@@ -1,20 +1,25 @@
 [c] func printf(fmt: str, ...) -> int; // A
 
-func dont_move(a: &int) {
+/**
 
+this will fail because we borrow x into y, then
+we try to use x later however the lifetime of y 
+hasn't ended so it's still being borrowed. 
+
+func main() -> int {
+    x: int = 21;
+    y: &int = &x;
+    C::printf("x is %d\n", x);
+    return 0;
 }
 
-func move_something(a: int) {
+**/
 
-}
-
-func move_return_ownership(a: int) -> int{
-    return a;
-}
-
-func main() -> int { // B
-    mut x: int = 10;
-    dont_move(&x);
+func main() -> int {
+    x: int = 21;
+    {
+        y: &int = &x;
+    }
     C::printf("x is %d\n", x);
     return 0;
 }

--- a/tests/move_semantic_test.ark
+++ b/tests/move_semantic_test.ark
@@ -1,0 +1,20 @@
+[c] func printf(fmt: str, ...) -> int; // A
+
+func dont_move(a: &int) {
+
+}
+
+func move_something(a: int) {
+
+}
+
+func move_return_ownership(a: int) -> int{
+    return a;
+}
+
+func main() -> int { // B
+    mut x: int = 10;
+    dont_move(&x);
+    C::printf("x is %d\n", x);
+    return 0;
+}


### PR DESCRIPTION
This PR adds support for:
- simple move semantics
- simple borrowing
#### Move Semantics

Given these examples:

```
// takes a reference, is borrowed
func dont_move(a: &int) {

}

// moves something, no ownership returned
func move_something(a: int) {

}

// moves, but ownership is returned
func move_return_ownership(a: int) -> int{
    return a;
}
```

This will work fine since we borrow `x`

```
func main() -> int { // B
    mut x: int = 10;
    dont_move(&x);
    C::printf("x is %d\n", x);
    return 0;
}
```

As will this since we return ownership

```
func main() -> int { // B
    mut x: int = 10;
    x = move_return_ownership(x);
    C::printf("x is %d\n", x);
    return 0;
}
```

This will fail since we don't return ownership:

```
func main() -> int { // B
    mut x: int = 10;
    move_something(x);
    C::printf("x is %d\n", x); // errors here...
    return 0;
}
```
#### Simple Borrows

```
func main() -> int {
    x: int = 21;
    y: &int = &x;
    C::printf("x is %d\n", x);
    return 0;
}
```

Will fail as you are using `x` which has been borrowed, a nice error message is given:

```
error: [borrow_test:21:28] use of borrowed value x
    C::printf("x is %d\n", x);
```
