### PR TITLE
Add binary comparator for non-simple enums

### DIFF
--- a/src/codegen/LLVMCodegen/codegen.go
+++ b/src/codegen/LLVMCodegen/codegen.go
@@ -1155,6 +1155,14 @@ func (v *Codegen) genBinop(operator parser.BinOpType, resType, lhandType, rhandT
 
 		// Comparison
 		case parser.BINOP_GREATER, parser.BINOP_LESS, parser.BINOP_GREATER_EQ, parser.BINOP_LESS_EQ, parser.BINOP_EQ, parser.BINOP_NOT_EQ:
+			if isNonSimpleEnum(lhandType) {
+				lhand = v.builder().CreateExtractValue(lhand, 0, "lhand_tag")
+			}
+
+			if isNonSimpleEnum(rhandType) {
+				rhand = v.builder().CreateExtractValue(rhand, 0, "rhand_tag")
+			}
+
 			if lhandType.IsFloatingType() {
 				return v.builder().CreateFCmp(comparisonOpToFloatPredicate(operator), lhand, rhand, "")
 			} else {
@@ -1434,4 +1442,9 @@ func createStructInitializer(typ parser.Type) *parser.StructLiteral {
 		return lit
 	}
 	return nil
+}
+
+func isNonSimpleEnum(typ parser.Type) bool {
+	enum, ok := typ.ActualType().(parser.EnumType)
+	return ok && !enum.Simple
 }

--- a/src/semantic/type.go
+++ b/src/semantic/type.go
@@ -171,11 +171,12 @@ func (v *TypeCheck) CheckUnaryExpr(s *SemanticAnalyzer, expr *parser.UnaryExpr) 
 func (v *TypeCheck) CheckBinaryExpr(s *SemanticAnalyzer, expr *parser.BinaryExpr) {
 	switch expr.Op {
 	case parser.BINOP_EQ, parser.BINOP_NOT_EQ:
+		_, isEnum := expr.Lhand.GetType().ActualType().(parser.EnumType)
 		if !expr.Lhand.GetType().Equals(expr.Rhand.GetType()) {
 			s.Err(expr, "Operands for binary operator `%s` must have the same type, have `%s` and `%s`",
 				expr.Op.OpString(), expr.Lhand.GetType().TypeName(), expr.Rhand.GetType().TypeName())
-		} else if lht := expr.Lhand.GetType(); !(lht == parser.PRIMITIVE_bool || lht == parser.PRIMITIVE_rune || lht.IsIntegerType() || lht.IsFloatingType() || lht.LevelsOfIndirection() > 0) {
-			s.Err(expr, "Operands for binary operator `%s` must be numeric, or pointers or booleans, have `%s`",
+		} else if lht := expr.Lhand.GetType(); !(lht == parser.PRIMITIVE_bool || lht == parser.PRIMITIVE_rune || lht.IsIntegerType() || lht.IsFloatingType() || isEnum || lht.LevelsOfIndirection() > 0) {
+			s.Err(expr, "Operands for binary operator `%s` must be numeric, or pointers, or booleans, or enum, have `%s`",
 				expr.Op.OpString(), expr.Lhand.GetType().TypeName())
 		}
 

--- a/tests/enum_comp.ark
+++ b/tests/enum_comp.ark
@@ -1,0 +1,25 @@
+[c] func printf(fmt: ^u8, ...) -> int;
+
+pub func main() -> int {
+  n := Entry::None;
+  v := Entry::Value;
+
+  print(n == Entry::None);
+  print(n != Entry::Value);
+
+  print(v == Entry::Value);
+  print(v != Entry::None);
+
+  print(Entry::Value(1) == Entry::Value(2));
+
+  return 0;
+}
+
+type Entry enum {
+  None,
+  Value(int),
+};
+
+func print(val: bool) {
+  C::printf(c"%d\n", val);
+}

--- a/tests/enum_comp.toml
+++ b/tests/enum_comp.toml
@@ -1,0 +1,19 @@
+Name       = "enum_comp"
+Sourcefile = "enum_comp.ark"
+
+CompilerArgs = []
+RunArgs      = []
+
+CompilerError = 0
+RunError      = 0
+
+Input = ""
+
+CompilerOutput = ""
+RunOutput      = """
+1
+1
+1
+1
+1
+"""


### PR DESCRIPTION
This change implements the `==` and `!=` operators for non-simple enums which may have an additional tuple or struct value. Previously the `enum_comp` test case would fail:

```
error: [enum-comp:7:9] Operands for binary operator `==` must be numeric, or pointers or booleans, have `Entry`
  print(n == Entry::None);
```

At the moment, only the tag is compared and not the optional content of the enum:

```
Entry::Value(1) == Entry::Value(2) // true;
```

However, there are cases in which this behaviour is wanted.
