### PR TITLE
Set correct position for FunctionAccessExpr

### DIFF
--- a/src/cmd/ark-testrunner/main.go
+++ b/src/cmd/ark-testrunner/main.go
@@ -240,6 +240,9 @@ func runCommand(out io.Writer, cmd string, args ...string) (int, error) {
 	}
 	command.Stdout, command.Stderr = ow, ow
 
+	// Disable coloring for matching compiler output
+	command.Env = append(os.Environ(), "COLOR=0")
+
 	// Start the test
 	if err := command.Start(); err != nil {
 		return -1, err

--- a/src/parser/resolve.go
+++ b/src/parser/resolve.go
@@ -343,6 +343,7 @@ func (v *Resolver) ResolveNode(node *Node) {
 				Function:   ident.Value.(*Function),
 				parameters: n.parameters,
 			}
+			(*node).setPos(n.Pos())
 			break
 		} else if ident.Type == IDENT_VARIABLE {
 			n.Variable = ident.Value.(*Variable)

--- a/src/util/color.go
+++ b/src/util/color.go
@@ -1,6 +1,9 @@
 package util
 
-import "runtime"
+import (
+	"os"
+	"runtime"
+)
 
 var (
 	TEXT_RESET   string = ""
@@ -15,6 +18,10 @@ var (
 )
 
 func init() {
+	if os.Getenv("COLOR") == "0" {
+		return
+	}
+
 	switch runtime.GOOS {
 	case "linux", "darwin", "freebsd":
 		TEXT_RESET = "\x1B[00m"

--- a/tests/func_type_mismatch.ark
+++ b/tests/func_type_mismatch.ark
@@ -1,0 +1,11 @@
+pub func main() -> int {
+  return invoke(sub, 55, 55);
+}
+
+func sub(a: int, b: int) -> int {
+  return a - b;
+}
+
+func invoke(fn: func(int, bool) -> int, a: int, b: int) -> int {
+  return fn(a, b);
+}

--- a/tests/func_type_mismatch.toml
+++ b/tests/func_type_mismatch.toml
@@ -1,0 +1,21 @@
+Name       = "func_type_mismatch"
+Sourcefile = "func_type_mismatch.ark"
+
+CompilerArgs = []
+RunArgs      = []
+
+CompilerError = 4
+RunError      = 0
+
+Input = ""
+
+CompilerOutput = """error: [func_type_mismatch:2:17] Mismatched types in function call: `func(int, int) -> int` and `func(int, bool) -> int`
+  return invoke(sub, 55, 55);
+                ^
+
+error: [func_type_mismatch:9:1] Function declaration must not be in function
+func invoke(fn: func(int, bool) -> int, a: int, b: int) -> int {
+^
+
+"""
+RunOutput      = ""


### PR DESCRIPTION
Before this change, the included test case would still fail but lack positioning information and therefore crashing the compiler:

```
$ ark build ./tests/func_type_mismatch.ark 
error: [:0:0] Mismatched types in function call: `func` and `func`
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
github.com/ark-lang/ark/src/lexer.(*Sourcefile).MarkPos(0xc820134070, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /home/marius/workspace/go/src/github.com/ark-lang/ark/src/lexer/sourcefile.go:51 +0x4c5
github.com/ark-lang/ark/src/semantic.(*SemanticAnalyzer).Err(0xc820129600, 0x7f6bcaaa22a0, 0xc820129280, 0x982420, 0x30, 0xc8200f8a68, 0x2, 0x2)
    /home/marius/workspace/go/src/github.com/ark-lang/ark/src/semantic/semantic.go:35 +0x3ef

…
```
