### PR TITLE
Disallow attributes on anonymous types

### DIFF
--- a/src/ast/ast.go
+++ b/src/ast/ast.go
@@ -1171,7 +1171,7 @@ func (_ ArrayAccessExpr) NodeName() string {
 
 func (v ArrayAccessExpr) Mutable() bool {
 	if pt, ok := v.Array.GetType().BaseType.ActualType().(PointerType); ok {
-		return pt.IsMutable;
+		return pt.IsMutable
 	}
 	return v.Array.Mutable()
 }

--- a/src/ast/ast.go
+++ b/src/ast/ast.go
@@ -990,7 +990,7 @@ func (v CallExpr) GetType() *TypeReference {
 	if v.Function != nil {
 		fnType := v.Function.GetType()
 		if fnType != nil {
-			if fnType, ok := fnType.BaseType.(FunctionType); ok {
+			if fnType, ok := fnType.BaseType.ActualType().(FunctionType); ok {
 				return fnType.Return
 			}
 		}

--- a/src/ast/constructor.go
+++ b/src/ast/constructor.go
@@ -385,6 +385,7 @@ func (c *Constructor) constructTypeDeclNode(v *parser.TypeDeclNode) *TypeDecl {
 		Name:         v.Name.Value,
 		Type:         c.constructType(v.Type),
 		ParentModule: c.module,
+		attrs:        v.Attrs(),
 	}
 
 	res := &TypeDecl{

--- a/src/ast/inference.go
+++ b/src/ast/inference.go
@@ -1278,13 +1278,13 @@ func (v *Inferrer) Finalize() {
 			}
 
 			if n.Function != nil {
-				if _, ok := n.Function.GetType().BaseType.(FunctionType); !ok {
+				if _, ok := n.Function.GetType().BaseType.ActualType().(FunctionType); !ok {
 					v.errPos(n.Function.Pos(), "Attempt to call non-function `%s`", n.Function.GetType().String())
 				}
 
 				// Insert a deref in cases where the code tries to call a value reciver
 				// with a pointer type.
-				if recType := n.Function.GetType().BaseType.(FunctionType).Receiver; recType != nil {
+				if recType := n.Function.GetType().BaseType.ActualType().(FunctionType).Receiver; recType != nil {
 					accessType := n.ReceiverAccess.GetType()
 
 					if accessType.BaseType.LevelsOfIndirection() == recType.BaseType.LevelsOfIndirection()+1 {

--- a/src/ast/type.go
+++ b/src/ast/type.go
@@ -261,6 +261,7 @@ type NamedType struct {
 	ParentModule  *Module
 	Methods       []*Function
 	StaticMethods []*Function
+	attrs         parser.AttrGroup
 }
 
 func (v *NamedType) addMethod(fn *Function) {
@@ -327,7 +328,14 @@ func (v *NamedType) CanCastTo(t Type) bool {
 }
 
 func (v *NamedType) Attrs() parser.AttrGroup {
-	return v.Type.Attrs()
+	attrs := make(parser.AttrGroup)
+	if v.Type.Attrs() != nil {
+		attrs.Extend(v.Type.Attrs())
+	}
+	if v.attrs != nil {
+		attrs.Extend(v.attrs)
+	}
+	return attrs
 }
 
 func (v *NamedType) Equals(t Type) bool {
@@ -342,6 +350,11 @@ func (v *NamedType) Equals(t Type) bool {
 
 	if v.Name != other.Name {
 		return false
+	}
+
+	// Sanity check
+	if !v.attrs.Equals(other.attrs) {
+		panic("INTERNAL ERROR: Encountered equal named types with different attrs")
 	}
 
 	return true

--- a/src/ast/type.go
+++ b/src/ast/type.go
@@ -339,6 +339,10 @@ func (v *NamedType) Attrs() parser.AttrGroup {
 }
 
 func (v *NamedType) Equals(t Type) bool {
+	if _, ok := t.(FunctionType); ok {
+		return t.Equals(v)
+	}
+
 	other, ok := t.(*NamedType)
 	if !ok {
 		return false
@@ -978,12 +982,24 @@ func (v FunctionType) Attrs() parser.AttrGroup {
 }
 
 func (v FunctionType) Equals(t Type) bool {
-	other, ok := t.(FunctionType)
-	if !ok {
-		return false
+	var other FunctionType
+	var otherAttrs parser.AttrGroup
+	if named, ok := t.(*NamedType); ok {
+		ft, ok := named.Type.(FunctionType)
+		if !ok {
+			return false
+		}
+		other = ft
+		otherAttrs = named.Attrs()
+	} else {
+		ft, ok := t.(FunctionType)
+		if !ok {
+			return false
+		}
+		other = ft
 	}
 
-	if !v.Attrs().Equals(other.Attrs()) {
+	if !v.Attrs().Equals(otherAttrs) {
 		return false
 	}
 

--- a/src/codegen/LLVMCodegen/codegen.go
+++ b/src/codegen/LLVMCodegen/codegen.go
@@ -1682,7 +1682,7 @@ func (v *Codegen) genCastExpr(n *ast.CastExpr) llvm.Value {
 func (v *Codegen) genCallExprWithArgs(n *ast.CallExpr, args []llvm.Value) llvm.Value {
 	call := v.builder().CreateCall(v.genExprAndLoadIfNeccesary(n.Function), args, "")
 
-	attrs := n.Function.GetType().BaseType.(ast.FunctionType).Attrs()
+	attrs := n.Function.GetType().BaseType.ActualType().(ast.FunctionType).Attrs()
 	if attr, ok := attrs["call_conv"]; ok {
 		call.SetInstructionCallConv(callConvTypes[attr.Value])
 	}

--- a/src/parser/parser.go
+++ b/src/parser/parser.go
@@ -1304,11 +1304,6 @@ func (v *parser) parseType(doNamed bool, onlyComposites bool, mustParse bool) Pa
 		}
 	}()
 
-	// If the next token is a [ and identifier it must be a group of attributes
-	if v.tokenMatches(0, lexer.Separator, "[") && v.tokenMatches(1, lexer.Identifier, "") {
-		attrs = v.parseAttributes()
-	}
-
 	if !onlyComposites {
 		if v.tokenMatches(0, lexer.Identifier, KEYWORD_FUNC) {
 			res = v.parseFunctionType()

--- a/src/semantic/type.go
+++ b/src/semantic/type.go
@@ -350,7 +350,7 @@ func (v *TypeCheck) CheckCastExpr(s *SemanticAnalyzer, expr *ast.CastExpr) {
 }
 
 func (v *TypeCheck) CheckCallExpr(s *SemanticAnalyzer, expr *ast.CallExpr) {
-	fnType := expr.Function.GetType().BaseType.(ast.FunctionType)
+	fnType := expr.Function.GetType().BaseType.ActualType().(ast.FunctionType)
 
 	argLen := len(expr.Arguments)
 	paramLen := len(fnType.Parameters)

--- a/tests/call_conv.ark
+++ b/tests/call_conv.ark
@@ -7,6 +7,9 @@ func sub(a: int, b: int) -> int {
   return a - b;
 }
 
-func invoke(fn: [call_conv="x86fastcall"] func(int, int) -> int, a: int, b: int) -> int {
+[call_conv="x86fastcall"]
+type AFuncType func(int, int) -> int;
+
+func invoke(fn: AFuncType, a: int, b: int) -> int {
   return fn(a, b);
 }


### PR DESCRIPTION
After discussion with @0xbadb002 on IRC, we came to the conclusion that attributes should not be allowed on anonymous types. This is partly to work around an ambiguity issue with array types, but also to solve a lot of the confusion about attributes on types.

You now need a type decl if you want to put attributes on a type. If a named type "points" to another named type, the attributes on the outer decl takes precedence.

Closes #577
